### PR TITLE
Rewrite email addresses to lowercase for Users page

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -325,7 +325,7 @@ class UsersController extends Controller
             // 1) Core user
             $user = User::create([
                 'username'     => $username,
-                'user_email'   => $data['user_email'],
+                'user_email'   => Str::lower($data['user_email']),
                 'user_enabled' => $data['user_enabled'] ?? 'true',
                 'domain_uuid'  => $data['domain_uuid'] ?? session('domain_uuid'),
             ]);
@@ -411,6 +411,9 @@ class UsersController extends Controller
     {
 
         $validated   = $request->validated();
+        if (isset($validated['user_email'])) {
+            $validated['user_email'] = Str::lower($validated['user_email']);
+        }
         $domain_uuid = session('domain_uuid');
         // logger($validated);
 


### PR DESCRIPTION
We ran into situations where users would copy and paste email addresses that were mixed with upper and lower case letters. This would cause confusions when users try to login. Now we are saving in the database as lowercase. 

Eventually we will want to have the main login screen also strtolower for the email address field in case someone types their email address with a mix of cases