### PR TITLE
Show Verto (WebRTC) clients on Extensions registration list

### DIFF
--- a/app/Services/FreeswitchEslService.php
+++ b/app/Services/FreeswitchEslService.php
@@ -216,7 +216,70 @@ class FreeswitchEslService
             }
         }
 
+        // Also include Verto (WebRTC) clients
+        $vertoClients = $this->getVertoClients();
+        foreach ($vertoClients as $client) {
+            $registrations[] = $client;
+        }
+
         return collect($registrations);
+    }
+
+    /**
+     * Get connected Verto (WebRTC) clients from mod_verto.
+     */
+    function getVertoClients(): array
+    {
+        if (!extension_loaded('esl') || !$this->isConnected()) {
+            return [];
+        }
+
+        try {
+            $eslEvent = $this->conn->api('verto jsonstatus');
+            if (!$eslEvent) {
+                return [];
+            }
+
+            $body = trim($eslEvent->getBody());
+            $data = json_decode($body, true);
+
+            if (!$data || !isset($data['profiles'])) {
+                return [];
+            }
+
+            $clients = [];
+            foreach ($data['profiles'] as $profile) {
+                foreach ($profile['users'] ?? [] as $user) {
+                    // Verto user login format is typically "extension@domain"
+                    $login = $user['login'] ?? '';
+                    $parts = explode('@', $login);
+                    $extension = $parts[0] ?? '';
+                    $domain = $parts[1] ?? '';
+
+                    $clients[] = [
+                        'call_id' => $user['sessid'] ?? '',
+                        'user' => $login,
+                        'status' => 'Registered(Verto)',
+                        'lan_ip' => '',
+                        'port' => '',
+                        'contact' => 'verto/' . $login,
+                        'agent' => $user['agent'] ?? 'Verto WebRTC',
+                        'transport' => 'WSS',
+                        'wan_ip' => $user['ip'] ?? '',
+                        'sip_profile_name' => $profile['name'] ?? 'verto',
+                        'sip_auth_user' => $extension,
+                        'sip_auth_realm' => $domain,
+                        'ping_time' => '',
+                        'expsecs' => '',
+                    ];
+                }
+            }
+
+            return $clients;
+        } catch (\Throwable $e) {
+            logger('getVertoClients error: ' . $e->getMessage());
+            return [];
+        }
     }
 
     function getAllChannels()


### PR DESCRIPTION
## Summary

Query `mod_verto jsonstatus` alongside the existing sofia `xmlstatus` query in `FreeswitchEslService::getAllSipRegistrations()` so WebRTC-connected extensions show up as registered (transport \`WSS\`) on the Extensions page.

Without this, an extension connected via a Verto/WebRTC app (e.g. an iOS softphone over WebSockets) shows offline even though FreeSWITCH can reach it.

## Why community-friendly

- Generic FreeSWITCH feature — Verto is stock, no provider-specific code.
- Soft-fail: if `mod_verto` is not loaded or returns no JSON, the new block returns `[]` and the existing sofia output is unchanged.
- Single-file change in a single service.

## Test plan

- [ ] Connect a Verto/WebRTC client to FreeSWITCH (any softphone supporting WSS, e.g. SignalWire JS SDK).
- [ ] Visit the Extensions page — confirm the extension renders as registered with transport \`WSS\`.
- [ ] Disable / unload \`mod_verto\` — confirm the page still loads and sofia-only registrations still display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
