### PR TITLE
Add (domain_uuid, start_epoch) composite index to v_xml_cdr

### DIFF
--- a/database/migrations/2026_04_22_172847_add_domain_start_epoch_index_to_v_xml_cdr_table.php
+++ b/database/migrations/2026_04_22_172847_add_domain_start_epoch_index_to_v_xml_cdr_table.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::statement('CREATE INDEX IF NOT EXISTS v_xml_cdr_domain_uuid_start_epoch_idx ON v_xml_cdr (domain_uuid, start_epoch DESC)');
+    }
+
+    public function down(): void
+    {
+        DB::statement('DROP INDEX IF EXISTS v_xml_cdr_domain_uuid_start_epoch_idx');
+    }
+};


### PR DESCRIPTION
## Summary

Adds a composite index `(domain_uuid, start_epoch DESC)` on `v_xml_cdr`. Tenant-scoped CDR list queries always filter by `domain_uuid` and order by `start_epoch` descending; without a composite index the planner has to sort every batch of matched rows.

## Why community-friendly

- Pure performance win — backwards-compatible, no behaviour change.
- Benefits the new \`CdrController\` introduced in 4e13865b as well as any other tenant-scoped CDR query.
- Uses \`CREATE INDEX IF NOT EXISTS\` / \`DROP INDEX IF EXISTS\` so it is safe to run on databases that already have an equivalent index from a prior install.

## Test plan

- [ ] Run \`php artisan migrate\` against a populated v_xml_cdr table — verify the index appears (\`\\d v_xml_cdr\` in psql).
- [ ] \`EXPLAIN ANALYZE\` a tenant CDR list query (e.g. \`SELECT ... FROM v_xml_cdr WHERE domain_uuid = '...' ORDER BY start_epoch DESC LIMIT 50\`) before and after — confirm the planner picks the new index.
- [ ] Run \`php artisan migrate:rollback\` — verify the index is dropped cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)