### PR TITLE
Add outbound MOS + jitter + packet loss columns to v_xml_cdr

### DIFF
--- a/database/migrations/2026_04_22_180319_add_outbound_quality_columns_to_v_xml_cdr.php
+++ b/database/migrations/2026_04_22_180319_add_outbound_quality_columns_to_v_xml_cdr.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('v_xml_cdr', function (Blueprint $table) {
+            if (! Schema::hasColumn('v_xml_cdr', 'rtp_audio_out_mos')) {
+                $table->decimal('rtp_audio_out_mos', 4, 2)->nullable();
+            }
+            if (! Schema::hasColumn('v_xml_cdr', 'rtp_audio_in_jitter_ms')) {
+                $table->decimal('rtp_audio_in_jitter_ms', 8, 3)->nullable();
+            }
+            if (! Schema::hasColumn('v_xml_cdr', 'rtp_audio_in_packet_loss')) {
+                $table->decimal('rtp_audio_in_packet_loss', 5, 2)->nullable();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('v_xml_cdr', function (Blueprint $table) {
+            if (Schema::hasColumn('v_xml_cdr', 'rtp_audio_out_mos')) {
+                $table->dropColumn('rtp_audio_out_mos');
+            }
+            if (Schema::hasColumn('v_xml_cdr', 'rtp_audio_in_jitter_ms')) {
+                $table->dropColumn('rtp_audio_in_jitter_ms');
+            }
+            if (Schema::hasColumn('v_xml_cdr', 'rtp_audio_in_packet_loss')) {
+                $table->dropColumn('rtp_audio_in_packet_loss');
+            }
+        });
+    }
+};


### PR DESCRIPTION
## Summary

Extends \`v_xml_cdr\` with three nullable columns:

- \`rtp_audio_out_mos\` (decimal 4,2) — outbound MOS estimate
- \`rtp_audio_in_jitter_ms\` (decimal 8,3) — inbound jitter in ms
- \`rtp_audio_in_packet_loss\` (decimal 5,2) — inbound packet loss percentage

FreeSWITCH already publishes these metrics on hangup; stock fspbx persists only the inbound MOS, so the rest of the data is silently dropped. Surfacing them lets tenants render a more useful call-quality picture in CDR views.

## Why community-friendly

- Schema-only change. No behaviour shifts in this PR — population from FreeSWITCH variables and UI consumption is intentionally left for a follow-up so this can land independently.
- Idempotent: each \`addColumn\` is wrapped in \`Schema::hasColumn\` checks; the rollback is symmetric.
- Backwards compatible: columns are nullable, no default coercion.

## Test plan

- [ ] \`php artisan migrate\` against an existing v_xml_cdr — verify the three columns are added and existing rows remain intact.
- [ ] \`php artisan migrate:rollback\` — verify columns are dropped cleanly.
- [ ] Re-run \`php artisan migrate\` — confirm idempotency.

## Follow-up (out of scope for this PR)

Wire the FreeSWITCH variables \`rtp_audio_out_mos\`, \`rtp_audio_in_jitter\`, \`rtp_audio_in_packet_count\` (or equivalents) into the CDR insert pipeline; expose them in the CDR list/detail views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)