### PR TITLE
Add Call Flow simulation API (v1)

### DIFF
--- a/app/Data/Api/V1/CallFlow/CallFlowBranchData.php
+++ b/app/Data/Api/V1/CallFlow/CallFlowBranchData.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Data\Api\V1\CallFlow;
+
+use Spatie\LaravelData\Data;
+
+class CallFlowBranchData extends Data
+{
+    public function __construct(
+        public string $condition,
+        public ?string $label,
+        public bool $active,
+        public CallFlowNodeData $child,
+    ) {}
+}

--- a/app/Data/Api/V1/CallFlow/CallFlowNodeData.php
+++ b/app/Data/Api/V1/CallFlow/CallFlowNodeData.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Data\Api\V1\CallFlow;
+
+use Spatie\LaravelData\Data;
+
+class CallFlowNodeData extends Data
+{
+    /**
+     * @param array<int, CallFlowBranchData> $branches
+     * @param array<string, mixed>|null $metadata
+     */
+    public function __construct(
+        public string $node_id,
+        public string $type,
+        public string $label,
+        public ?string $resource_uuid,
+        public ?string $extension,
+        public ?array $metadata,
+        public array $branches,
+    ) {}
+}

--- a/app/Data/Api/V1/CallFlow/CallFlowSimulationData.php
+++ b/app/Data/Api/V1/CallFlow/CallFlowSimulationData.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Data\Api\V1\CallFlow;
+
+use Spatie\LaravelData\Data;
+
+class CallFlowSimulationData extends Data
+{
+    /**
+     * @param array<int, string> $warnings
+     */
+    public function __construct(
+        public string $object,
+        public string $url,
+        public string $domain_uuid,
+        public ?string $domain_name,
+        public string $phone_number,
+        public string $evaluated_at,
+        public ?string $timezone,
+        public CallFlowNodeData $tree,
+        public array $warnings,
+    ) {}
+}

--- a/app/Http/Controllers/Api/V1/CallFlowSimulationController.php
+++ b/app/Http/Controllers/Api/V1/CallFlowSimulationController.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Data\Api\V1\CallFlow\CallFlowSimulationData;
+use App\Exceptions\ApiException;
+use App\Http\Controllers\Controller;
+use App\Services\CallFlow\CallFlowMermaidRenderer;
+use App\Services\CallFlow\CallFlowSimulator;
+use DateTimeImmutable;
+use DateTimeZone;
+use Illuminate\Http\Request;
+
+class CallFlowSimulationController extends Controller
+{
+    public function __construct(
+        protected CallFlowSimulator $simulator,
+        protected CallFlowMermaidRenderer $mermaid,
+    ) {}
+
+    /**
+     * Simulate the call flow for an inbound phone number at a point in time.
+     *
+     * Returns a tree showing every branch the call could take (business
+     * hours, IVR digit options, ring-group member progression, extension
+     * no-answer → voicemail, etc.). Branches are labelled with their trigger
+     * ("in_hours", "press_2", "no_answer") and the branch that is active
+     * right now for the supplied timestamp is marked `active: true`.
+     *
+     * Access rules:
+     * - Tenant token: must match the domain_uuid in the URL.
+     * - Global token: may access any domain.
+     * - Caller must have the `call_flow_simulate` permission.
+     *
+     * @group Call Flow
+     * @authenticated
+     *
+     * @urlParam domain_uuid string required The domain UUID.
+     *
+     * @queryParam phone_number string required Inbound DID to simulate. Accepts E.164 (+441225800810) or national digits. Example: +441225800810
+     * @queryParam at string ISO 8601 timestamp to evaluate at; defaults to now. Example: 2026-04-23T19:00:00Z
+     * @queryParam max_depth int Max tree depth (1–50, default 20).
+     * @queryParam format string One of: `json` (default), `mermaid`. Mermaid returns text/plain for diagram rendering.
+     */
+    public function simulate(Request $request, string $domain_uuid)
+    {
+        $this->assertUuid($domain_uuid, 'domain_uuid');
+        return $this->run($request, $domain_uuid);
+    }
+
+    /**
+     * Global simulate — any domain, global admin token required.
+     *
+     * @group Call Flow
+     * @authenticated
+     *
+     * @queryParam domain_uuid string required The domain UUID.
+     * @queryParam phone_number string required Inbound DID to simulate.
+     * @queryParam at string ISO 8601 timestamp to evaluate at; defaults to now.
+     * @queryParam max_depth int Max tree depth (1–50, default 20).
+     * @queryParam format string One of: `json` (default), `mermaid`.
+     */
+    public function globalSimulate(Request $request)
+    {
+        $domainUuid = trim((string) $request->query('domain_uuid', ''));
+        if ($domainUuid === '') {
+            throw new ApiException(
+                400,
+                'invalid_request_error',
+                'domain_uuid is required.',
+                'parameter_missing',
+                'domain_uuid',
+            );
+        }
+        $this->assertUuid($domainUuid, 'domain_uuid');
+        return $this->run($request, $domainUuid);
+    }
+
+    private function run(Request $request, string $domainUuid)
+    {
+        $phoneNumber = trim((string) $request->query('phone_number', ''));
+        if ($phoneNumber === '') {
+            throw new ApiException(
+                400,
+                'invalid_request_error',
+                'phone_number is required.',
+                'parameter_missing',
+                'phone_number',
+            );
+        }
+        if (strlen($phoneNumber) > 32) {
+            throw new ApiException(
+                400,
+                'invalid_request_error',
+                'phone_number is too long.',
+                'invalid_request',
+                'phone_number',
+            );
+        }
+
+        $at = $this->parseAt($request);
+        $maxDepth = $this->parseMaxDepth($request);
+
+        $format = strtolower((string) $request->query('format', 'json'));
+        if (! in_array($format, ['json', 'mermaid'], true)) {
+            throw new ApiException(
+                400,
+                'invalid_request_error',
+                'format must be one of json, mermaid.',
+                'invalid_request',
+                'format',
+            );
+        }
+
+        $simulation = $this->simulator->simulate($domainUuid, $phoneNumber, $at, $maxDepth);
+
+        if ($format === 'mermaid') {
+            return response($this->mermaid->render($simulation), 200)
+                ->header('Content-Type', 'text/plain; charset=utf-8');
+        }
+
+        return response()->json($simulation->toArray(), 200);
+    }
+
+    private function parseAt(Request $request): DateTimeImmutable
+    {
+        $raw = trim((string) $request->query('at', ''));
+        if ($raw === '') {
+            return new DateTimeImmutable('now', new DateTimeZone('UTC'));
+        }
+        try {
+            return new DateTimeImmutable($raw);
+        } catch (\Exception $e) {
+            throw new ApiException(
+                400,
+                'invalid_request_error',
+                'at must be a valid ISO 8601 timestamp.',
+                'invalid_request',
+                'at',
+            );
+        }
+    }
+
+    private function parseMaxDepth(Request $request): int
+    {
+        $v = (int) $request->query('max_depth', 20);
+        return max(1, min(50, $v));
+    }
+
+    private function assertUuid(string $value, string $field): void
+    {
+        if (! preg_match('/^[0-9a-fA-F-]{36}$/', $value)) {
+            throw new ApiException(
+                400,
+                'invalid_request_error',
+                'Invalid ' . $field . '.',
+                'invalid_request',
+                $field,
+            );
+        }
+    }
+}

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -72,5 +72,12 @@ class RouteServiceProvider extends ServiceProvider
                     return response('', 429);
                 });
         });
+
+        // Call-flow simulation walks several tables per request; cap it so an
+        // agent-tool loop can't hammer the DB.
+        RateLimiter::for('call-flow-simulate', function (Request $request) {
+            $key = $request->bearerToken() ?: (optional($request->user())->id ?: $request->ip());
+            return Limit::perMinute(10)->by('call-flow-simulate:' . $key);
+        });
     }
 }

--- a/app/Services/CallFlow/BusinessHoursEvaluator.php
+++ b/app/Services/CallFlow/BusinessHoursEvaluator.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace App\Services\CallFlow;
+
+use App\Models\BusinessHour;
+use App\Models\BusinessHourHoliday;
+use App\Models\BusinessHourPeriod;
+use DateTimeImmutable;
+use DateTimeZone;
+
+/**
+ * Decides whether a BusinessHour set is "in hours" at a given moment.
+ *
+ * Returns the specific period that is active (day, times) so the simulator can
+ * label the `in_hours` branch with the matching schedule row, or null if the
+ * time falls outside all periods (i.e. after-hours / holiday).
+ */
+class BusinessHoursEvaluator
+{
+    /**
+     * @return array{
+     *     period: ?BusinessHourPeriod,
+     *     holiday: ?BusinessHourHoliday,
+     *     is_in_hours: bool,
+     *     timezone: string,
+     *     warnings: array<int, string>
+     * }
+     */
+    public function evaluate(BusinessHour $businessHour, DateTimeImmutable $at): array
+    {
+        $timezone = $businessHour->timezone ?: 'UTC';
+        $local = $at->setTimezone(new DateTimeZone($timezone));
+
+        $warnings = [];
+
+        $holiday = $this->matchingHoliday($businessHour, $local, $warnings);
+        if ($holiday !== null) {
+            return [
+                'period' => null,
+                'holiday' => $holiday,
+                'is_in_hours' => false,
+                'timezone' => $timezone,
+                'warnings' => $warnings,
+            ];
+        }
+
+        $period = $this->matchingPeriod($businessHour, $local);
+
+        return [
+            'period' => $period,
+            'holiday' => null,
+            'is_in_hours' => $period !== null,
+            'timezone' => $timezone,
+            'warnings' => $warnings,
+        ];
+    }
+
+    private function matchingPeriod(BusinessHour $businessHour, DateTimeImmutable $local): ?BusinessHourPeriod
+    {
+        // FreeSWITCH / BusinessHour convention: 1=Sun…7=Sat. PHP `w` is 0=Sun…6=Sat.
+        $fsDow = ((int) $local->format('w')) + 1;
+        $nowSec = $this->secondsSinceMidnight($local);
+
+        foreach ($businessHour->periods as $period) {
+            if ((int) $period->day_of_week !== $fsDow) {
+                continue;
+            }
+            $start = $this->timeStringToSeconds((string) $period->start_time);
+            $end = $this->timeStringToSeconds((string) $period->end_time);
+            if ($start === null || $end === null) {
+                continue;
+            }
+            if ($start <= $end) {
+                if ($nowSec >= $start && $nowSec < $end) {
+                    return $period;
+                }
+            } else {
+                // Overnight period (e.g. 22:00–02:00)
+                if ($nowSec >= $start || $nowSec < $end) {
+                    return $period;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<int, string> $warnings
+     */
+    private function matchingHoliday(BusinessHour $businessHour, DateTimeImmutable $local, array &$warnings): ?BusinessHourHoliday
+    {
+        foreach ($businessHour->holidays as $holiday) {
+            $type = (string) $holiday->holiday_type;
+
+            if ($type === 'single_date' && $holiday->start_date !== null) {
+                if ($holiday->start_date->format('Y-m-d') === $local->format('Y-m-d')
+                    && $this->holidayTimeCovers($holiday, $local)) {
+                    return $holiday;
+                }
+                continue;
+            }
+
+            if ($type === 'date_range' && $holiday->start_date !== null && $holiday->end_date !== null) {
+                $today = $local->format('Y-m-d');
+                if ($today >= $holiday->start_date->format('Y-m-d')
+                    && $today <= $holiday->end_date->format('Y-m-d')
+                    && $this->holidayTimeCovers($holiday, $local)) {
+                    return $holiday;
+                }
+                continue;
+            }
+
+            // Recurring patterns (us_holiday, recurring_pattern) aren't evaluated
+            // in v1 — flag once so the caller can surface it.
+            $warnings[] = sprintf(
+                'business-hours holiday "%s" (type=%s) uses a recurring pattern that is not evaluated by the simulator',
+                (string) ($holiday->description ?: $holiday->uuid),
+                $type,
+            );
+        }
+
+        return null;
+    }
+
+    private function holidayTimeCovers(BusinessHourHoliday $holiday, DateTimeImmutable $local): bool
+    {
+        if (empty($holiday->start_time) || empty($holiday->end_time)) {
+            return true; // whole-day holiday
+        }
+        $nowSec = $this->secondsSinceMidnight($local);
+        $start = $this->timeStringToSeconds($holiday->start_time instanceof \DateTimeInterface
+            ? $holiday->start_time->format('H:i:s')
+            : (string) $holiday->start_time);
+        $end = $this->timeStringToSeconds($holiday->end_time instanceof \DateTimeInterface
+            ? $holiday->end_time->format('H:i:s')
+            : (string) $holiday->end_time);
+        if ($start === null || $end === null) {
+            return true;
+        }
+        return $nowSec >= $start && $nowSec < $end;
+    }
+
+    private function secondsSinceMidnight(DateTimeImmutable $local): int
+    {
+        return ((int) $local->format('H')) * 3600
+            + ((int) $local->format('i')) * 60
+            + (int) $local->format('s');
+    }
+
+    private function timeStringToSeconds(string $time): ?int
+    {
+        if (! preg_match('/^(\d{1,2}):(\d{2})(?::(\d{2}))?$/', $time, $m)) {
+            return null;
+        }
+        return ((int) $m[1]) * 3600 + ((int) $m[2]) * 60 + ((int) ($m[3] ?? 0));
+    }
+}

--- a/app/Services/CallFlow/CallFlowContext.php
+++ b/app/Services/CallFlow/CallFlowContext.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Services\CallFlow;
+
+use DateTimeImmutable;
+
+/**
+ * Traversal state shared across the recursive walk: depth/cycle guards,
+ * node-id sequence, and accumulated warnings.
+ */
+class CallFlowContext
+{
+    public int $depth = 0;
+    public int $nodeCounter = 0;
+
+    /** @var array<string, bool> */
+    public array $visited = [];
+
+    /** @var array<int, string> */
+    public array $warnings = [];
+
+    public function __construct(
+        public string $domainUuid,
+        public ?string $domainName,
+        public DateTimeImmutable $at,
+        public string $timezone,
+        public int $maxDepth = 20,
+    ) {}
+
+    public function nextNodeId(): string
+    {
+        return 'n' . (++$this->nodeCounter);
+    }
+
+    public function hasVisited(string $type, ?string $id): bool
+    {
+        if ($id === null || $id === '') {
+            return false;
+        }
+        return isset($this->visited[$type . ':' . $id]);
+    }
+
+    public function markVisited(string $type, ?string $id): void
+    {
+        if ($id !== null && $id !== '') {
+            $this->visited[$type . ':' . $id] = true;
+        }
+    }
+
+    public function warn(string $message): void
+    {
+        $this->warnings[] = $message;
+    }
+}

--- a/app/Services/CallFlow/CallFlowMermaidRenderer.php
+++ b/app/Services/CallFlow/CallFlowMermaidRenderer.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Services\CallFlow;
+
+use App\Data\Api\V1\CallFlow\CallFlowNodeData;
+use App\Data\Api\V1\CallFlow\CallFlowSimulationData;
+
+/**
+ * Renders a CallFlowSimulationData tree as a Mermaid `flowchart LR`
+ * diagram. Pure function of the tree — no DB calls, no side effects.
+ */
+class CallFlowMermaidRenderer
+{
+    public function render(CallFlowSimulationData $sim): string
+    {
+        $nodeLines = [];
+        $edgeLines = [];
+
+        $this->walk($sim->tree, null, null, false, $nodeLines, $edgeLines);
+
+        $body = implode("\n", array_merge(
+            array_map(fn ($l) => '  ' . $l, $nodeLines),
+            array_map(fn ($l) => '  ' . $l, $edgeLines),
+        ));
+
+        return "flowchart LR\n" . $body . "\n";
+    }
+
+    private function walk(
+        CallFlowNodeData $node,
+        ?string $parentId,
+        ?string $edgeCondition,
+        bool $edgeActive,
+        array &$nodeLines,
+        array &$edgeLines,
+    ): void {
+        $nodeLines[] = $node->node_id . '["' . $this->escapeLabel($this->composeLabel($node)) . '"]';
+
+        if ($parentId !== null && $edgeCondition !== null) {
+            $arrow = $edgeActive ? '==>' : '-->';
+            $edgeLines[] = $parentId . ' ' . $arrow . '|' . $this->escapeLabel($edgeCondition) . '| ' . $node->node_id;
+        }
+
+        foreach ($node->branches as $branch) {
+            $this->walk($branch->child, $node->node_id, $branch->label ?: $branch->condition, $branch->active, $nodeLines, $edgeLines);
+        }
+    }
+
+    private function composeLabel(CallFlowNodeData $node): string
+    {
+        $label = $node->label;
+        // Some node types already include the extension in the label; only
+        // append when not already present.
+        if ($node->extension !== null && ! str_contains($label, (string) $node->extension)) {
+            $label .= ' (' . $node->extension . ')';
+        }
+        return $this->truncate($label, 80);
+    }
+
+    private function truncate(string $s, int $max): string
+    {
+        if (mb_strlen($s) <= $max) {
+            return $s;
+        }
+        return mb_substr($s, 0, $max - 1) . '…';
+    }
+
+    private function escapeLabel(string $s): string
+    {
+        // Mermaid label-safe: drop double-quotes and backticks; collapse
+        // whitespace; escape pipe which delimits edge labels.
+        $s = preg_replace('/\s+/', ' ', $s);
+        $s = str_replace(['"', '`'], ["'", "'"], $s);
+        $s = str_replace('|', '/', $s);
+        return trim($s);
+    }
+}

--- a/app/Services/CallFlow/CallFlowSimulator.php
+++ b/app/Services/CallFlow/CallFlowSimulator.php
@@ -1,0 +1,692 @@
+<?php
+
+namespace App\Services\CallFlow;
+
+use App\Data\Api\V1\CallFlow\CallFlowBranchData;
+use App\Data\Api\V1\CallFlow\CallFlowNodeData;
+use App\Data\Api\V1\CallFlow\CallFlowSimulationData;
+use App\Exceptions\ApiException;
+use App\Models\BusinessHour;
+use App\Models\Destinations;
+use App\Models\Dialplans;
+use App\Models\Domain;
+use App\Models\Extensions;
+use App\Models\IvrMenus;
+use App\Models\RingGroups;
+use App\Models\Voicemails;
+use App\Services\CallRoutingOptionsService;
+use DateTimeImmutable;
+
+/**
+ * Walks the inbound-routing graph for a given (domain, phone_number, time)
+ * and produces a tree of `CallFlowNodeData` showing every branch a call could
+ * take. Terminal nodes are voicemail/hangup/external; interior nodes
+ * (business_hours, time_condition, ivr, ring_group, extension) expose their
+ * branches with labels so the caller can see "what happens now" and also
+ * "what happens if the user presses 2 / no one answers / it's after hours".
+ */
+class CallFlowSimulator
+{
+    public function __construct(
+        protected BusinessHoursEvaluator $businessHours,
+        protected TimeConditionEvaluator $timeConditions,
+        protected RingGroupStrategyEvaluator $ringGroups,
+    ) {}
+
+    public function simulate(
+        string $domainUuid,
+        string $phoneNumber,
+        DateTimeImmutable $at,
+        int $maxDepth = 20,
+    ): CallFlowSimulationData {
+        $domain = Domain::where('domain_uuid', $domainUuid)->first();
+        if (! $domain) {
+            throw new ApiException(
+                404,
+                'invalid_request_error',
+                'Domain not found.',
+                'resource_missing',
+                'domain_uuid',
+            );
+        }
+
+        $destination = $this->findDestination($domainUuid, $phoneNumber);
+        if (! $destination) {
+            throw new ApiException(
+                404,
+                'invalid_request_error',
+                'No phone number matching the supplied input was found for this domain.',
+                'resource_missing',
+                'phone_number',
+            );
+        }
+
+        $timezone = get_local_time_zone($domainUuid) ?: 'UTC';
+        $ctx = new CallFlowContext($domainUuid, $domain->domain_name, $at, $timezone, $maxDepth);
+
+        $tree = $this->walkDestination($destination, $ctx);
+
+        return new CallFlowSimulationData(
+            object: 'call_flow_simulation',
+            url: '/api/v1/domains/' . $domainUuid . '/call-flow/simulate',
+            domain_uuid: $domainUuid,
+            domain_name: $domain->domain_name,
+            phone_number: $this->displayPhoneNumber($phoneNumber, $destination),
+            evaluated_at: $at->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d\TH:i:s\Z'),
+            timezone: $timezone,
+            tree: $tree,
+            warnings: $ctx->warnings,
+        );
+    }
+
+    /**
+     * Find the Destinations row that matches the supplied number. Tries a few
+     * normalisations so callers can pass `+441225800810`, `01225800810`, or
+     * `1225800810` and hit the same row.
+     */
+    private function findDestination(string $domainUuid, string $phoneNumber): ?Destinations
+    {
+        $digits = preg_replace('/\D/', '', $phoneNumber);
+        if ($digits === '' || $digits === null) {
+            throw new ApiException(
+                400,
+                'invalid_request_error',
+                'phone_number must contain at least one digit.',
+                'invalid_request',
+                'phone_number',
+            );
+        }
+
+        $candidates = collect([$digits])
+            ->when(strlen($digits) > 1 && str_starts_with($digits, '0'), fn ($c) => $c->push(ltrim($digits, '0')));
+
+        $rows = Destinations::where('domain_uuid', $domainUuid)->get();
+
+        foreach ($rows as $row) {
+            $storedRaw = preg_replace('/\D/', '', (string) $row->destination_number);
+            $prefix = preg_replace('/\D/', '', (string) $row->destination_prefix);
+            $storedFull = $prefix . $storedRaw;
+
+            foreach ($candidates as $cand) {
+                if ($cand === '' || $cand === null) {
+                    continue;
+                }
+                if ($cand === $storedRaw || $cand === $storedFull) {
+                    return $row;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private function displayPhoneNumber(string $input, Destinations $destination): string
+    {
+        if (str_starts_with(trim($input), '+')) {
+            return trim($input);
+        }
+        $e164 = $destination->destination_number_e164;
+        return $e164 !== '' ? $e164 : trim($input);
+    }
+
+    private function walkDestination(Destinations $destination, CallFlowContext $ctx): CallFlowNodeData
+    {
+        $label = $destination->destination_number_e164
+            . ($destination->destination_description ? ' (' . $destination->destination_description . ')' : '');
+
+        $root = new CallFlowNodeData(
+            node_id: $ctx->nextNodeId(),
+            type: 'inbound_did',
+            label: $label,
+            resource_uuid: $destination->destination_uuid,
+            extension: null,
+            metadata: [
+                'destination_description' => $destination->destination_description,
+            ],
+            branches: [],
+        );
+
+        $service = new CallRoutingOptionsService($ctx->domainUuid);
+        $options = $service->reverseEngineerDestinationActions($destination->destination_actions) ?? [];
+
+        foreach ($options as $option) {
+            if (! is_array($option) || empty($option['type'])) {
+                continue;
+            }
+            $child = $this->walkOption($option, $ctx);
+            $root->branches[] = new CallFlowBranchData(
+                condition: 'enter',
+                label: null,
+                active: true,
+                child: $child,
+            );
+        }
+
+        if ($root->branches === []) {
+            $root->branches[] = new CallFlowBranchData(
+                condition: 'enter',
+                label: 'no routing configured',
+                active: true,
+                child: $this->terminalNode($ctx, 'unresolved', 'No routing configured on this DID', null, null, [
+                    'destination_actions' => $destination->destination_actions,
+                ]),
+            );
+            $ctx->warn('DID ' . $destination->destination_number_e164 . ' has no decodable destination_actions');
+        }
+
+        return $root;
+    }
+
+    /**
+     * Main type dispatch. $option shape is the output of
+     * CallRoutingOptionsService's reverseEngineer* methods:
+     *   ['type' => string|null, 'extension' => ?string, 'option' => ?string, 'name' => ?string]
+     */
+    public function walkOption(array $option, CallFlowContext $ctx): CallFlowNodeData
+    {
+        if ($ctx->depth >= $ctx->maxDepth) {
+            $ctx->warn('max traversal depth (' . $ctx->maxDepth . ') reached');
+            return $this->terminalNode($ctx, 'unresolved', 'max depth reached', null, null);
+        }
+
+        $type = (string) ($option['type'] ?? '');
+        $targetId = $option['option'] ?? null;
+
+        if ($ctx->hasVisited($type, $targetId)) {
+            $ctx->warn('cycle detected at ' . $type . ':' . ($targetId ?? ''));
+            return $this->terminalNode($ctx, 'cycle_detected', 'cycle: ' . $type, $targetId, $option['extension'] ?? null);
+        }
+        $ctx->markVisited($type, $targetId);
+        $ctx->depth++;
+
+        try {
+            return match ($type) {
+                'business_hours' => $this->walkBusinessHours($option, $ctx),
+                'ivrs' => $this->walkIvr($option, $ctx),
+                'ring_groups' => $this->walkRingGroup($option, $ctx),
+                'extensions' => $this->walkExtension($option, $ctx),
+                'voicemails' => $this->walkVoicemail($option, $ctx),
+                'time_conditions' => $this->walkTimeCondition($option, $ctx),
+                'hangup' => $this->terminalNode($ctx, 'hangup', 'Hang up'),
+                'check_voicemail' => $this->terminalNode($ctx, 'check_voicemail', 'Check Voicemail (*98)'),
+                'company_directory' => $this->terminalNode($ctx, 'company_directory', 'Company Directory'),
+                'external' => $this->terminalNode($ctx, 'external', 'External: ' . ($option['extension'] ?? ''), null, $option['extension'] ?? null),
+                'ai_agents' => $this->terminalNode($ctx, 'ai_agent', 'AI Agent ' . ($option['extension'] ?? ''), $targetId, $option['extension'] ?? null, ['name' => $option['name'] ?? null]),
+                'conferences' => $this->terminalNode($ctx, 'conference', 'Conference ' . ($option['extension'] ?? ''), $targetId, $option['extension'] ?? null, ['name' => $option['name'] ?? null]),
+                'contact_centers' => $this->terminalNode($ctx, 'contact_center', 'Contact Center ' . ($option['extension'] ?? ''), $targetId, $option['extension'] ?? null, ['name' => $option['name'] ?? null]),
+                'faxes' => $this->terminalNode($ctx, 'fax', 'Fax ' . ($option['extension'] ?? ''), $targetId, $option['extension'] ?? null, ['name' => $option['name'] ?? null]),
+                'call_flows' => $this->terminalNode($ctx, 'call_flow', 'Call Flow ' . ($option['extension'] ?? ''), $targetId, $option['extension'] ?? null, ['name' => $option['name'] ?? null]),
+                'recordings' => $this->terminalNode($ctx, 'recording', 'Play Recording', $targetId, null, ['name' => $option['name'] ?? null]),
+                default => $this->terminalNode($ctx, 'unresolved', 'Unresolved destination', $targetId, $option['extension'] ?? null, [
+                    'raw_option' => $option,
+                ]),
+            };
+        } finally {
+            $ctx->depth--;
+        }
+    }
+
+    private function walkBusinessHours(array $option, CallFlowContext $ctx): CallFlowNodeData
+    {
+        $bh = BusinessHour::with(['periods', 'holidays'])
+            ->where('uuid', $option['option'] ?? '')
+            ->first();
+
+        $node = new CallFlowNodeData(
+            node_id: $ctx->nextNodeId(),
+            type: 'business_hours',
+            label: $bh ? ('Business Hours: ' . ($bh->name ?: $option['extension'] ?? '')) : ('Business Hours ' . ($option['extension'] ?? '')),
+            resource_uuid: $bh?->uuid,
+            extension: $option['extension'] ?? $bh?->extension ?? null,
+            metadata: null,
+            branches: [],
+        );
+
+        if (! $bh) {
+            $ctx->warn('business_hours record not found: ' . ($option['option'] ?? ''));
+            return $node;
+        }
+
+        $eval = $this->businessHours->evaluate($bh, $ctx->at);
+        foreach ($eval['warnings'] as $w) {
+            $ctx->warn($w);
+        }
+        $node->metadata = [
+            'timezone' => $eval['timezone'],
+            'is_in_hours' => $eval['is_in_hours'],
+            'active_period' => $eval['period'] ? $this->describePeriod($eval['period']) : null,
+            'active_holiday' => $eval['holiday'] ? (string) ($eval['holiday']->description ?? $eval['holiday']->uuid) : null,
+        ];
+
+        // In-hours branch: walk each period that exists (we pick one "active"
+        // — the one that matches the current time if any).
+        $periodTarget = $this->businessHoursPeriodTarget($bh, $eval['period'], $ctx);
+        if ($periodTarget !== null) {
+            $node->branches[] = new CallFlowBranchData(
+                condition: 'in_hours',
+                label: $eval['period'] ? $this->describePeriod($eval['period']) : 'in hours',
+                active: $eval['is_in_hours'],
+                child: $this->walkOption($periodTarget, $ctx),
+            );
+        }
+
+        // After-hours branch.
+        $afterHoursTarget = $this->businessHoursAfterHoursTarget($bh, $ctx);
+        if ($afterHoursTarget !== null) {
+            $node->branches[] = new CallFlowBranchData(
+                condition: 'after_hours',
+                label: 'after hours',
+                active: ! $eval['is_in_hours'] && $eval['holiday'] === null,
+                child: $this->walkOption($afterHoursTarget, $ctx),
+            );
+        }
+
+        // Holiday branch, if any applies right now.
+        if ($eval['holiday'] !== null) {
+            $holidayTarget = $this->holidayTarget($eval['holiday'], $ctx);
+            if ($holidayTarget !== null) {
+                $node->branches[] = new CallFlowBranchData(
+                    condition: 'holiday',
+                    label: (string) ($eval['holiday']->description ?? 'holiday'),
+                    active: true,
+                    child: $this->walkOption($holidayTarget, $ctx),
+                );
+            }
+        }
+
+        return $node;
+    }
+
+    private function businessHoursPeriodTarget(BusinessHour $bh, $period, CallFlowContext $ctx): ?array
+    {
+        // Prefer the currently active period; fall back to the first period
+        // that has a target so the in_hours branch still renders.
+        $candidates = $period ? [$period] : [];
+        foreach ($bh->periods as $p) {
+            if ($period === null || $p->uuid !== $period->uuid) {
+                $candidates[] = $p;
+            }
+        }
+        foreach ($candidates as $p) {
+            $target = $this->polymorphicTargetToOption($p->target_type ?? null, $p->target_id ?? null, $ctx);
+            if ($target !== null) {
+                return $target;
+            }
+        }
+        return null;
+    }
+
+    private function businessHoursAfterHoursTarget(BusinessHour $bh, CallFlowContext $ctx): ?array
+    {
+        return $this->polymorphicTargetToOption(
+            $bh->after_hours_target_type,
+            $bh->after_hours_target_id,
+            $ctx,
+        );
+    }
+
+    private function holidayTarget($holiday, CallFlowContext $ctx): ?array
+    {
+        return $this->polymorphicTargetToOption($holiday->target_type ?? null, $holiday->target_id ?? null, $ctx);
+    }
+
+    /**
+     * Translate a Laravel morphTo pair into a routing option array that
+     * walkOption() can consume. Supports the BusinessHour target types.
+     */
+    private function polymorphicTargetToOption(?string $targetType, ?string $targetId, CallFlowContext $ctx): ?array
+    {
+        if (! $targetType || ! $targetId) {
+            return null;
+        }
+
+        $class = class_basename($targetType);
+
+        return match ($class) {
+            'Extensions' => [
+                'type' => 'extensions',
+                'option' => $targetId,
+                'extension' => $this->extensionNumberByUuid($targetId),
+                'name' => null,
+            ],
+            'Voicemails' => [
+                'type' => 'voicemails',
+                'option' => $targetId,
+                'extension' => null,
+                'name' => null,
+            ],
+            'RingGroups' => [
+                'type' => 'ring_groups',
+                'option' => $targetId,
+                'extension' => null,
+                'name' => null,
+            ],
+            'IvrMenus' => [
+                'type' => 'ivrs',
+                'option' => $targetId,
+                'extension' => null,
+                'name' => null,
+            ],
+            'Dialplans' => [
+                'type' => 'time_conditions',
+                'option' => $targetId,
+                'extension' => null,
+                'name' => null,
+            ],
+            'Recordings' => ['type' => 'recordings', 'option' => $targetId, 'extension' => null, 'name' => null],
+            'CallCenterQueues' => ['type' => 'contact_centers', 'option' => $targetId, 'extension' => null, 'name' => null],
+            'Faxes' => ['type' => 'faxes', 'option' => $targetId, 'extension' => null, 'name' => null],
+            'CallFlows' => ['type' => 'call_flows', 'option' => $targetId, 'extension' => null, 'name' => null],
+            default => null,
+        };
+    }
+
+    private function extensionNumberByUuid(string $uuid): ?string
+    {
+        $ext = Extensions::where('extension_uuid', $uuid)->first();
+        return $ext?->extension;
+    }
+
+    private function describePeriod($period): string
+    {
+        $days = [1 => 'Sun', 2 => 'Mon', 3 => 'Tue', 4 => 'Wed', 5 => 'Thu', 6 => 'Fri', 7 => 'Sat'];
+        $dayName = $days[(int) $period->day_of_week] ?? (string) $period->day_of_week;
+        return $dayName . ' ' . substr((string) $period->start_time, 0, 5) . '–' . substr((string) $period->end_time, 0, 5);
+    }
+
+    private function walkIvr(array $option, CallFlowContext $ctx): CallFlowNodeData
+    {
+        $ivr = IvrMenus::with('options')
+            ->where('ivr_menu_uuid', $option['option'] ?? '')
+            ->first();
+
+        $node = new CallFlowNodeData(
+            node_id: $ctx->nextNodeId(),
+            type: 'ivr',
+            label: $ivr ? ('IVR: ' . $ivr->ivr_menu_name . ' (ext ' . $ivr->ivr_menu_extension . ')') : ('IVR ' . ($option['extension'] ?? '')),
+            resource_uuid: $ivr?->ivr_menu_uuid,
+            extension: $option['extension'] ?? $ivr?->ivr_menu_extension,
+            metadata: $ivr ? [
+                'timeout_sec' => (int) $ivr->ivr_menu_timeout,
+            ] : null,
+            branches: [],
+        );
+
+        if (! $ivr) {
+            $ctx->warn('ivr_menu record not found: ' . ($option['option'] ?? ''));
+            return $node;
+        }
+
+        $service = new CallRoutingOptionsService($ctx->domainUuid);
+
+        foreach ($ivr->options as $opt) {
+            if ((string) ($opt->ivr_menu_option_enabled ?? 'true') === 'false') {
+                continue;
+            }
+            $action = (string) ($opt->ivr_menu_option_action ?? '');
+            $param = (string) ($opt->ivr_menu_option_param ?? '');
+            $full = trim($action . ' ' . $param);
+            if ($full === '') {
+                continue;
+            }
+            $parsed = $service->reverseEngineerIVROption($full);
+            $child = $parsed && ! empty($parsed['type'])
+                ? $this->walkOption($parsed, $ctx)
+                : $this->terminalNode($ctx, 'unresolved', 'IVR option unresolved', null, null, ['raw' => $full]);
+
+            $node->branches[] = new CallFlowBranchData(
+                condition: 'press_' . (string) $opt->ivr_menu_option_digits,
+                label: (string) ($opt->ivr_menu_option_description ?: ('press ' . $opt->ivr_menu_option_digits)),
+                active: false,
+                child: $child,
+            );
+        }
+
+        // Timeout / invalid fallback: use ivr_menu_exit_app+data.
+        $exitAction = trim(($ivr->ivr_menu_exit_app ?? '') . ' ' . ($ivr->ivr_menu_exit_data ?? ''));
+        if ($exitAction !== '') {
+            $parsed = $service->reverseEngineerIVROption($exitAction);
+            if ($parsed && ! empty($parsed['type'])) {
+                $node->branches[] = new CallFlowBranchData(
+                    condition: 'timeout',
+                    label: 'no input (timeout)',
+                    active: false,
+                    child: $this->walkOption($parsed, $ctx),
+                );
+            }
+        }
+
+        return $node;
+    }
+
+    private function walkRingGroup(array $option, CallFlowContext $ctx): CallFlowNodeData
+    {
+        $group = RingGroups::with('destinations')
+            ->where('ring_group_uuid', $option['option'] ?? '')
+            ->first();
+
+        if (! $group) {
+            $ctx->warn('ring_group record not found: ' . ($option['option'] ?? ''));
+            return $this->terminalNode($ctx, 'ring_group', 'Ring Group ' . ($option['extension'] ?? ''), $option['option'] ?? null, $option['extension'] ?? null);
+        }
+
+        return $this->ringGroups->expand($group, $ctx, fn (array $opt) => $this->walkOption($opt, $ctx));
+    }
+
+    private function walkExtension(array $option, CallFlowContext $ctx): CallFlowNodeData
+    {
+        $ext = null;
+        if (! empty($option['option'])) {
+            $ext = Extensions::where('extension_uuid', $option['option'])->first();
+        }
+        if (! $ext && ! empty($option['extension'])) {
+            $ext = Extensions::where('domain_uuid', $ctx->domainUuid)
+                ->where('extension', $option['extension'])
+                ->first();
+        }
+
+        $node = new CallFlowNodeData(
+            node_id: $ctx->nextNodeId(),
+            type: 'extension',
+            label: $ext
+                ? ('Extension: ' . $ext->extension . ($ext->effective_caller_id_name ? ' - ' . $ext->effective_caller_id_name : ''))
+                : ('Extension ' . ($option['extension'] ?? '')),
+            resource_uuid: $ext?->extension_uuid,
+            extension: $ext?->extension ?? $option['extension'] ?? null,
+            metadata: $ext ? [
+                'call_timeout_sec' => (int) $ext->call_timeout,
+                'enabled' => $ext->enabled,
+                'do_not_disturb' => $ext->do_not_disturb,
+            ] : null,
+            branches: [],
+        );
+
+        if (! $ext) {
+            return $node;
+        }
+
+        $service = new CallRoutingOptionsService($ctx->domainUuid);
+
+        // forward_all takes precedence at runtime — emit it as a branch the
+        // support agent can see is active if enabled.
+        if ((string) $ext->forward_all_enabled === 'true' && filled($ext->forward_all_destination)) {
+            $parsed = $service->reverseEngineerForwardAction($ext->forward_all_destination);
+            if ($parsed && ! empty($parsed['type'])) {
+                $node->branches[] = new CallFlowBranchData(
+                    condition: 'forward_all',
+                    label: 'forward-all (always)',
+                    active: true,
+                    child: $this->walkOption($parsed, $ctx),
+                );
+                return $node;
+            }
+        }
+
+        if ((string) $ext->forward_busy_enabled === 'true' && filled($ext->forward_busy_destination)) {
+            $parsed = $service->reverseEngineerForwardAction($ext->forward_busy_destination);
+            if ($parsed && ! empty($parsed['type'])) {
+                $node->branches[] = new CallFlowBranchData(
+                    condition: 'busy',
+                    label: 'on busy',
+                    active: false,
+                    child: $this->walkOption($parsed, $ctx),
+                );
+            }
+        }
+
+        // no_answer: explicit forward first, else default to personal voicemail
+        // at *99<ext> if the extension has one (matches FusionPBX default).
+        $noAnswerHandled = false;
+        if ((string) $ext->forward_no_answer_enabled === 'true' && filled($ext->forward_no_answer_destination)) {
+            $parsed = $service->reverseEngineerForwardAction($ext->forward_no_answer_destination);
+            if ($parsed && ! empty($parsed['type'])) {
+                $node->branches[] = new CallFlowBranchData(
+                    condition: 'no_answer',
+                    label: 'after ' . ((int) $ext->call_timeout) . 's no-answer',
+                    active: false,
+                    child: $this->walkOption($parsed, $ctx),
+                );
+                $noAnswerHandled = true;
+            }
+        }
+        if (! $noAnswerHandled) {
+            $vm = Voicemails::where('domain_uuid', $ctx->domainUuid)
+                ->where('voicemail_id', $ext->extension)
+                ->first();
+            if ($vm) {
+                $node->branches[] = new CallFlowBranchData(
+                    condition: 'no_answer',
+                    label: 'after ' . ((int) $ext->call_timeout) . 's → voicemail',
+                    active: false,
+                    child: $this->walkOption([
+                        'type' => 'voicemails',
+                        'option' => $vm->voicemail_uuid,
+                        'extension' => $vm->voicemail_id,
+                        'name' => null,
+                    ], $ctx),
+                );
+            }
+        }
+
+        return $node;
+    }
+
+    private function walkVoicemail(array $option, CallFlowContext $ctx): CallFlowNodeData
+    {
+        $vm = null;
+        if (! empty($option['option'])) {
+            $vm = Voicemails::where('voicemail_uuid', $option['option'])->first();
+        }
+        if (! $vm && ! empty($option['extension'])) {
+            $vm = Voicemails::where('domain_uuid', $ctx->domainUuid)
+                ->where('voicemail_id', $option['extension'])
+                ->first();
+        }
+
+        return new CallFlowNodeData(
+            node_id: $ctx->nextNodeId(),
+            type: 'voicemail',
+            label: $vm ? ('Voicemail ' . $vm->voicemail_id) : ('Voicemail ' . ($option['extension'] ?? '')),
+            resource_uuid: $vm?->voicemail_uuid,
+            extension: $vm?->voicemail_id ?? $option['extension'] ?? null,
+            metadata: null,
+            branches: [],
+        );
+    }
+
+    private function walkTimeCondition(array $option, CallFlowContext $ctx): CallFlowNodeData
+    {
+        $dialplan = null;
+        if (! empty($option['option'])) {
+            $dialplan = Dialplans::where('dialplan_uuid', $option['option'])->first();
+        }
+
+        $node = new CallFlowNodeData(
+            node_id: $ctx->nextNodeId(),
+            type: 'time_condition',
+            label: $dialplan ? ('Schedule: ' . $dialplan->dialplan_name) : ('Schedule ' . ($option['extension'] ?? '')),
+            resource_uuid: $dialplan?->dialplan_uuid,
+            extension: $dialplan?->dialplan_number ?? $option['extension'] ?? null,
+            metadata: null,
+            branches: [],
+        );
+
+        if (! $dialplan || empty($dialplan->dialplan_xml)) {
+            $ctx->warn('time_condition dialplan missing XML: ' . ($option['option'] ?? ''));
+            return $node;
+        }
+
+        $service = new CallRoutingOptionsService($ctx->domainUuid);
+
+        try {
+            $evaluation = $this->timeConditions->evaluate($dialplan->dialplan_xml, $ctx->at, $ctx->timezone);
+        } catch (TimeConditionParseException $e) {
+            $ctx->warn('failed to parse time_condition XML: ' . $e->getMessage());
+            return $node;
+        }
+
+        $node->metadata = [
+            'matched_summary' => $evaluation['matched_summary'],
+        ];
+
+        if ($evaluation['matched_action']) {
+            $child = $this->actionToOptionThenWalk($evaluation['matched_action'], $service, $ctx);
+            $node->branches[] = new CallFlowBranchData(
+                condition: 'time_match',
+                label: $evaluation['matched_summary'] ?: 'matches current time',
+                active: true,
+                child: $child,
+            );
+        }
+
+        if ($evaluation['fallback_action']) {
+            $child = $this->actionToOptionThenWalk($evaluation['fallback_action'], $service, $ctx);
+            $node->branches[] = new CallFlowBranchData(
+                condition: 'time_no_match',
+                label: 'fallthrough',
+                active: $evaluation['matched_action'] === null,
+                child: $child,
+            );
+        }
+
+        return $node;
+    }
+
+    private function actionToOptionThenWalk(array $action, CallRoutingOptionsService $service, CallFlowContext $ctx): CallFlowNodeData
+    {
+        $app = $action['destination_app'] ?? '';
+        $data = $action['destination_data'] ?? '';
+
+        if ($app === 'transfer') {
+            $parsed = $service->reverseEngineerIVROption(trim('transfer ' . $data));
+        } elseif ($app === 'hangup') {
+            $parsed = ['type' => 'hangup'];
+        } else {
+            $parsed = null;
+        }
+
+        if (! $parsed || empty($parsed['type'])) {
+            return $this->terminalNode($ctx, 'unresolved', $app . ' ' . $data, null, null, ['raw' => $action]);
+        }
+        return $this->walkOption($parsed, $ctx);
+    }
+
+    public function terminalNode(
+        CallFlowContext $ctx,
+        string $type,
+        string $label,
+        ?string $resourceUuid = null,
+        ?string $extension = null,
+        ?array $metadata = null,
+    ): CallFlowNodeData {
+        return new CallFlowNodeData(
+            node_id: $ctx->nextNodeId(),
+            type: $type,
+            label: $label,
+            resource_uuid: $resourceUuid,
+            extension: $extension,
+            metadata: $metadata,
+            branches: [],
+        );
+    }
+}

--- a/app/Services/CallFlow/RingGroupStrategyEvaluator.php
+++ b/app/Services/CallFlow/RingGroupStrategyEvaluator.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace App\Services\CallFlow;
+
+use App\Data\Api\V1\CallFlow\CallFlowBranchData;
+use App\Data\Api\V1\CallFlow\CallFlowNodeData;
+use App\Models\Extensions;
+use App\Models\RingGroups;
+use App\Services\CallRoutingOptionsService;
+use Closure;
+
+/**
+ * Expands a ring group into a tree that reflects its ring strategy:
+ *
+ *  - sequence / rollover      → chained `ring_group_member` nodes, each
+ *                               with its own `no_answer` branch pointing at
+ *                               either the next member or the group exit.
+ *  - simultaneous / enterprise → single `ring_group` node whose members are
+ *                               recorded as metadata and one
+ *                               `member_timeout` branch to the group exit.
+ *  - random                   → `ring_group` node with members; order is
+ *                               nondeterministic (warning attached).
+ *
+ * The caller provides a `walker` closure (the main simulator's walkOption)
+ * so children can recurse back through the normal dispatch.
+ */
+class RingGroupStrategyEvaluator
+{
+    /**
+     * @param Closure $walker  fn(array $option): CallFlowNodeData
+     */
+    public function expand(RingGroups $group, CallFlowContext $ctx, Closure $walker): CallFlowNodeData
+    {
+        $strategy = strtolower((string) ($group->ring_group_strategy ?? 'simultaneous'));
+        $timeoutSec = (int) ($group->ring_group_call_timeout ?? 0);
+        $members = $group->destinations
+            ->sortBy(function ($m) {
+                return [(int) ($m->destination_delay ?? 0), (string) $m->destination_number];
+            })
+            ->values();
+
+        $groupLabel = 'Ring Group: ' . $group->ring_group_name . ' (ext ' . $group->ring_group_extension . ')';
+
+        $groupExit = $this->groupExitOption($group);
+
+        if (in_array($strategy, ['sequence', 'rollover', 'sequential'], true)) {
+            return $this->buildSequential($group, $members, $groupExit, $ctx, $walker);
+        }
+
+        if ($strategy === 'random') {
+            $ctx->warn('ring_group ' . $group->ring_group_extension . ' uses random strategy — member order is nondeterministic at runtime');
+        }
+
+        // simultaneous / enterprise / random: one node, parallel ring.
+        $memberSummaries = [];
+        foreach ($members as $m) {
+            $memberSummaries[] = [
+                'extension' => (string) $m->destination_number,
+                'delay_sec' => (int) ($m->destination_delay ?? 0),
+                'timeout_sec' => (int) ($m->destination_timeout ?: $timeoutSec),
+                'prompt' => (string) ($m->destination_prompt ?? ''),
+            ];
+        }
+
+        $node = new CallFlowNodeData(
+            node_id: $ctx->nextNodeId(),
+            type: 'ring_group',
+            label: $groupLabel,
+            resource_uuid: $group->ring_group_uuid,
+            extension: $group->ring_group_extension,
+            metadata: [
+                'strategy' => $strategy,
+                'call_timeout_sec' => $timeoutSec,
+                'members' => $memberSummaries,
+            ],
+            branches: [],
+        );
+
+        if ($groupExit !== null) {
+            $node->branches[] = new CallFlowBranchData(
+                condition: 'member_timeout',
+                label: 'all members ' . $timeoutSec . 's no-answer',
+                active: false,
+                child: $walker($groupExit),
+            );
+        }
+
+        return $node;
+    }
+
+    private function buildSequential(RingGroups $group, $members, ?array $groupExit, CallFlowContext $ctx, Closure $walker): CallFlowNodeData
+    {
+        $timeoutSec = (int) ($group->ring_group_call_timeout ?? 0);
+
+        $header = new CallFlowNodeData(
+            node_id: $ctx->nextNodeId(),
+            type: 'ring_group',
+            label: 'Ring Group: ' . $group->ring_group_name . ' (ext ' . $group->ring_group_extension . ', sequential)',
+            resource_uuid: $group->ring_group_uuid,
+            extension: $group->ring_group_extension,
+            metadata: [
+                'strategy' => 'sequence',
+                'call_timeout_sec' => $timeoutSec,
+            ],
+            branches: [],
+        );
+
+        if ($members->isEmpty()) {
+            if ($groupExit !== null) {
+                $header->branches[] = new CallFlowBranchData(
+                    condition: 'member_timeout',
+                    label: 'no members',
+                    active: false,
+                    child: $walker($groupExit),
+                );
+            }
+            return $header;
+        }
+
+        // Build the chain head-first so each member's no_answer branch points
+        // at the next member, with the last member falling back to group exit.
+        $head = null;
+        $tail = null;
+
+        foreach ($members as $m) {
+            $memberTimeout = (int) ($m->destination_timeout ?: $timeoutSec);
+            $memberNode = $this->buildMemberNode($group, $m, $ctx, $walker);
+            $memberNode->metadata = array_merge($memberNode->metadata ?? [], [
+                'timeout_sec' => $memberTimeout,
+                'delay_sec' => (int) ($m->destination_delay ?? 0),
+            ]);
+
+            if ($head === null) {
+                $head = $memberNode;
+                $tail = $memberNode;
+            } else {
+                $tail->branches[] = new CallFlowBranchData(
+                    condition: 'member_next',
+                    label: 'no answer, next member',
+                    active: false,
+                    child: $memberNode,
+                );
+                $tail = $memberNode;
+            }
+        }
+
+        // Final fallback from tail → group exit.
+        if ($tail !== null && $groupExit !== null) {
+            $tail->branches[] = new CallFlowBranchData(
+                condition: 'member_timeout',
+                label: 'all members exhausted',
+                active: false,
+                child: $walker($groupExit),
+            );
+        }
+
+        $header->branches[] = new CallFlowBranchData(
+            condition: 'enter',
+            label: 'ring first member',
+            active: true,
+            child: $head,
+        );
+
+        return $header;
+    }
+
+    private function buildMemberNode(RingGroups $group, $member, CallFlowContext $ctx, Closure $walker): CallFlowNodeData
+    {
+        $destNumber = (string) $member->destination_number;
+
+        // External SIP URI member (e.g. sip:alice@external.example) — terminal.
+        if (str_contains($destNumber, '@') || str_starts_with($destNumber, 'sip:')) {
+            return new CallFlowNodeData(
+                node_id: $ctx->nextNodeId(),
+                type: 'ring_group_member',
+                label: 'External: ' . $destNumber,
+                resource_uuid: null,
+                extension: $destNumber,
+                metadata: ['target_kind' => 'external'],
+                branches: [],
+            );
+        }
+
+        // Internal extension — walk through a shallow extension node. We
+        // don't recurse into forward-all/busy to avoid exploding the tree
+        // for deep org charts; we rely on the main extension walker for the
+        // per-extension detail when the simulator targets an extension
+        // directly. Here we just show that the member rings.
+        $ext = Extensions::where('domain_uuid', $group->domain_uuid)
+            ->where('extension', $destNumber)
+            ->first();
+
+        return new CallFlowNodeData(
+            node_id: $ctx->nextNodeId(),
+            type: 'ring_group_member',
+            label: $ext
+                ? ('Member ext ' . $ext->extension . ($ext->effective_caller_id_name ? ' - ' . $ext->effective_caller_id_name : ''))
+                : ('Member ext ' . $destNumber),
+            resource_uuid: $ext?->extension_uuid,
+            extension: $destNumber,
+            metadata: [
+                'target_kind' => $ext ? 'extension' : 'unknown',
+                'do_not_disturb' => $ext?->do_not_disturb,
+                'enabled' => $ext?->enabled,
+            ],
+            branches: [],
+        );
+    }
+
+    private function groupExitOption(RingGroups $group): ?array
+    {
+        $exitAction = trim(($group->ring_group_timeout_app ?? '') . ' ' . ($group->ring_group_timeout_data ?? ''));
+        if ($exitAction === '') {
+            return null;
+        }
+        $service = new CallRoutingOptionsService($group->domain_uuid);
+        $parsed = $service->reverseEngineerRingGroupExitAction($exitAction);
+        return ($parsed && ! empty($parsed['type'])) ? $parsed : null;
+    }
+}

--- a/app/Services/CallFlow/TimeConditionEvaluator.php
+++ b/app/Services/CallFlow/TimeConditionEvaluator.php
@@ -1,0 +1,274 @@
+<?php
+
+namespace App\Services\CallFlow;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use SimpleXMLElement;
+
+/**
+ * Evaluates a FusionPBX "time condition" dialplan's XML against a point in time.
+ *
+ * Time-condition dialplans are XML documents whose `<condition>` elements carry
+ * one or more time attributes (`hour="9-17" wday="2-6"` etc.). FreeSWITCH runs
+ * the first matching condition's actions; a trailing condition with no time
+ * attributes acts as the fallthrough. We mirror that: return the action of the
+ * first condition whose time predicates all match, plus the action of the
+ * first subsequent condition with no time predicates as a documented fallback
+ * so the simulator can emit both "what happens now" and "what the fallback is"
+ * branches.
+ */
+class TimeConditionEvaluator
+{
+    /** Attribute names that carry time predicates. */
+    private const TIME_FIELDS = [
+        'year', 'mon', 'mday', 'yday', 'wday', 'week', 'mweek',
+        'hour', 'minute', 'minute-of-day', 'time-of-day', 'date-time',
+    ];
+
+    /**
+     * @return array{
+     *     matched_action: ?array{destination_app: string, destination_data: ?string},
+     *     fallback_action: ?array{destination_app: string, destination_data: ?string},
+     *     matched_summary: ?string
+     * }
+     */
+    public function evaluate(string $dialplanXml, DateTimeImmutable $at, string $timezone): array
+    {
+        $local = $at->setTimezone(new DateTimeZone($timezone ?: 'UTC'));
+
+        $xml = $this->load($dialplanXml);
+
+        $matchedAction = null;
+        $matchedSummary = null;
+        $fallbackAction = null;
+
+        foreach ($xml->xpath('//condition') ?: [] as $condition) {
+            $timeAttrs = $this->timeAttributes($condition);
+
+            if ($timeAttrs === []) {
+                // First unconditional condition = fallback; don't return early
+                // because a time-conditional condition may appear above it.
+                if ($fallbackAction === null) {
+                    $fallbackAction = $this->firstTransferAction($condition);
+                }
+                continue;
+            }
+
+            if ($matchedAction !== null) {
+                continue;
+            }
+
+            if ($this->conditionMatches($timeAttrs, $local)) {
+                $matchedAction = $this->firstTransferAction($condition);
+                $matchedSummary = $this->summarise($timeAttrs);
+            }
+        }
+
+        return [
+            'matched_action' => $matchedAction,
+            'fallback_action' => $fallbackAction,
+            'matched_summary' => $matchedSummary,
+        ];
+    }
+
+    private function load(string $xml): SimpleXMLElement
+    {
+        $previous = libxml_use_internal_errors(true);
+        try {
+            $parsed = @simplexml_load_string($xml);
+            if ($parsed === false) {
+                throw new TimeConditionParseException('dialplan XML failed to parse');
+            }
+            return $parsed;
+        } finally {
+            libxml_clear_errors();
+            libxml_use_internal_errors($previous);
+        }
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function timeAttributes(SimpleXMLElement $condition): array
+    {
+        $out = [];
+        foreach (self::TIME_FIELDS as $field) {
+            $value = (string) ($condition[$field] ?? '');
+            if ($value !== '') {
+                $out[$field] = $value;
+            }
+        }
+        return $out;
+    }
+
+    /**
+     * @param array<string, string> $attrs
+     */
+    private function conditionMatches(array $attrs, DateTimeImmutable $local): bool
+    {
+        foreach ($attrs as $field => $expression) {
+            if (! $this->fieldMatches($field, $expression, $local)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private function fieldMatches(string $field, string $expression, DateTimeImmutable $local): bool
+    {
+        switch ($field) {
+            case 'year':
+                return $this->matchIntRangeList((int) $local->format('Y'), $expression);
+            case 'mon':
+                return $this->matchIntRangeList((int) $local->format('n'), $expression);
+            case 'mday':
+                return $this->matchIntRangeList((int) $local->format('j'), $expression);
+            case 'yday':
+                // PHP `z` is 0-indexed (0=Jan 1); FreeSWITCH yday is 1-indexed.
+                return $this->matchIntRangeList(((int) $local->format('z')) + 1, $expression);
+            case 'wday':
+                // FreeSWITCH wday: 1=Sun…7=Sat. PHP `w` is 0=Sun…6=Sat.
+                return $this->matchIntRangeList(((int) $local->format('w')) + 1, $expression);
+            case 'week':
+                return $this->matchIntRangeList((int) $local->format('W'), $expression);
+            case 'mweek':
+                return $this->matchIntRangeList((int) ceil(((int) $local->format('j')) / 7), $expression);
+            case 'hour':
+                return $this->matchIntRangeList((int) $local->format('G'), $expression);
+            case 'minute':
+                return $this->matchIntRangeList((int) $local->format('i'), $expression);
+            case 'minute-of-day':
+                $mod = ((int) $local->format('G')) * 60 + (int) $local->format('i') + 1;
+                return $this->matchIntRangeList($mod, $expression);
+            case 'time-of-day':
+                return $this->matchTimeOfDay($local, $expression);
+            case 'date-time':
+                return $this->matchDateTime($local, $expression);
+        }
+        return false;
+    }
+
+    /**
+     * Matches integer values against FreeSWITCH range-list expressions.
+     * Accepts "5", "1-5", "1,3,5", "1-5,7,9-11". Supports overnight wrap
+     * (e.g. "22-6") for fields where that makes sense.
+     */
+    private function matchIntRangeList(int $value, string $expression): bool
+    {
+        foreach (explode(',', $expression) as $part) {
+            $part = trim($part);
+            if ($part === '') {
+                continue;
+            }
+            if (str_contains($part, '-')) {
+                [$a, $b] = array_map('trim', explode('-', $part, 2));
+                if ($a === '' || $b === '' || ! is_numeric($a) || ! is_numeric($b)) {
+                    continue;
+                }
+                $lo = (int) $a;
+                $hi = (int) $b;
+                if ($lo <= $hi) {
+                    if ($value >= $lo && $value <= $hi) {
+                        return true;
+                    }
+                } else {
+                    // Overnight wrap: e.g. 22-6 means 22,23,0,1,2,3,4,5,6.
+                    if ($value >= $lo || $value <= $hi) {
+                        return true;
+                    }
+                }
+            } else {
+                if (is_numeric($part) && $value === (int) $part) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Matches `time-of-day` expressions like "09:00-17:30". Supports overnight
+     * wrap (e.g. "22:00-06:00") by treating wrap as "lo..end-of-day OR 0..hi".
+     */
+    private function matchTimeOfDay(DateTimeImmutable $local, string $expression): bool
+    {
+        $parts = explode('-', $expression, 2);
+        if (count($parts) !== 2) {
+            return false;
+        }
+        $loMin = $this->timeOfDayToMinutes(trim($parts[0]));
+        $hiMin = $this->timeOfDayToMinutes(trim($parts[1]));
+        if ($loMin === null || $hiMin === null) {
+            return false;
+        }
+        $nowMin = ((int) $local->format('G')) * 60 + (int) $local->format('i');
+
+        if ($loMin <= $hiMin) {
+            return $nowMin >= $loMin && $nowMin <= $hiMin;
+        }
+        return $nowMin >= $loMin || $nowMin <= $hiMin;
+    }
+
+    private function timeOfDayToMinutes(string $hhmm): ?int
+    {
+        if (! preg_match('/^(\d{1,2}):(\d{2})$/', $hhmm, $m)) {
+            return null;
+        }
+        $h = (int) $m[1];
+        $min = (int) $m[2];
+        if ($h < 0 || $h > 23 || $min < 0 || $min > 59) {
+            return null;
+        }
+        return $h * 60 + $min;
+    }
+
+    /**
+     * Matches `date-time` expressions like "2026-04-23 09:00~2026-04-23 17:00".
+     * Evaluated in the same timezone as $local.
+     */
+    private function matchDateTime(DateTimeImmutable $local, string $expression): bool
+    {
+        $parts = explode('~', $expression, 2);
+        if (count($parts) !== 2) {
+            return false;
+        }
+        try {
+            $from = new DateTimeImmutable(trim($parts[0]), $local->getTimezone());
+            $to = new DateTimeImmutable(trim($parts[1]), $local->getTimezone());
+        } catch (\Throwable $e) {
+            return false;
+        }
+        return $local >= $from && $local <= $to;
+    }
+
+    private function firstTransferAction(SimpleXMLElement $condition): ?array
+    {
+        foreach ($condition->children() as $child) {
+            if ($child->getName() !== 'action') {
+                continue;
+            }
+            $app = (string) ($child['application'] ?? '');
+            if ($app === '' || $app === 'set' || $app === 'export' || $app === 'log') {
+                continue;
+            }
+            return [
+                'destination_app' => $app,
+                'destination_data' => (string) ($child['data'] ?? ''),
+            ];
+        }
+        return null;
+    }
+
+    /**
+     * @param array<string, string> $attrs
+     */
+    private function summarise(array $attrs): string
+    {
+        $bits = [];
+        foreach ($attrs as $field => $expression) {
+            $bits[] = "{$field}={$expression}";
+        }
+        return implode(' ', $bits);
+    }
+}

--- a/app/Services/CallFlow/TimeConditionParseException.php
+++ b/app/Services/CallFlow/TimeConditionParseException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Services\CallFlow;
+
+use RuntimeException;
+
+class TimeConditionParseException extends RuntimeException
+{
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -155,6 +155,8 @@ class DatabaseSeeder extends Seeder
             ['application_name' => 'XML CDR', 'permission_name' => 'xml_cdr_view_self_records'],
             ['application_name' => 'Messages', 'permission_name' => 'messages_view'],
             ['application_name' => 'Messages', 'permission_name' => 'messages_view_as'],
+            ['application_name' => 'Call Flow API', 'permission_name' => 'call_flow_simulate'],
+            ['application_name' => 'Call Flow API', 'permission_name' => 'call_flow_simulate_all_domains'],
         ];
         $timestamp = date("Y-m-d H:i:s");
 

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -180,6 +180,8 @@ class DatabaseSeeder extends Seeder
             ['application_name' => 'Basic Dialer', 'permission_name' => 'basic_dialer_update'],
             ['application_name' => 'Basic Dialer', 'permission_name' => 'basic_dialer_delete'],
             ['application_name' => 'Basic Dialer', 'permission_name' => 'basic_dialer_start'],
+            ['application_name' => 'Call Flow API', 'permission_name' => 'call_flow_simulate'],
+            ['application_name' => 'Call Flow API', 'permission_name' => 'call_flow_simulate_all_domains'],
         ];
         $timestamp = date("Y-m-d H:i:s");
 

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Api\V1\RingGroupController;
 use App\Http\Controllers\Api\V1\VoicemailController;
 use App\Http\Controllers\Api\V1\PhoneNumberController;
 use App\Http\Controllers\Api\V1\CdrController;
+use App\Http\Controllers\Api\V1\CallFlowSimulationController;
 
 /*
 |--------------------------------------------------------------------------
@@ -149,4 +150,27 @@ Route::middleware(['auth:sanctum', 'api.token.auth', 'throttle:api'])->group(fun
 
     Route::get('/domains/{domain_uuid}/cdrs/{xml_cdr_uuid}', [CdrController::class, 'show'])
         ->middleware('user.authorize:xml_cdr_view');
+
+    /*
+    |--------------------------------------------------------------------------
+    | Call Flow Simulation — domain-scoped, read-only
+    |--------------------------------------------------------------------------
+    | Walks the dialplan tree starting from a given DID at a given timestamp
+    | and returns the active branch + every alternative. Dedicated throttle
+    | because each simulation walks several tables per call.
+    */
+    Route::middleware(['user.authorize:call_flow_simulate', 'throttle:call-flow-simulate'])->group(function () {
+        Route::get('/domains/{domain_uuid}/call-flow/simulate', [CallFlowSimulationController::class, 'simulate'])
+            ->name('api.v1.call-flow.simulate');
+    });
+
+    /*
+    |--------------------------------------------------------------------------
+    | Call Flow Simulation — global (cross-domain, admin)
+    |--------------------------------------------------------------------------
+    */
+    Route::middleware(['user.authorize:call_flow_simulate_all_domains', 'throttle:call-flow-simulate'])->group(function () {
+        Route::get('/call-flow/simulate', [CallFlowSimulationController::class, 'globalSimulate'])
+            ->name('api.v1.call-flow.global.simulate');
+    });
 });

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -11,6 +11,7 @@ use App\Http\Controllers\Api\V1\RingGroupController;
 use App\Http\Controllers\Api\V1\VoicemailController;
 use App\Http\Controllers\Api\V1\PhoneNumberController;
 use App\Http\Controllers\Api\V1\CdrController;
+use App\Http\Controllers\Api\V1\CallFlowSimulationController;
 
 /*
 |--------------------------------------------------------------------------
@@ -192,4 +193,27 @@ Route::middleware(['auth:sanctum', 'api.token.auth', 'throttle:api'])->group(fun
 
     Route::get('/domains/{domain_uuid}/cdrs/{xml_cdr_uuid}/recording-url', [CdrController::class, 'recordingUrl'])
         ->middleware('user.authorize:xml_cdr_view');
+
+    /*
+    |--------------------------------------------------------------------------
+    | Call Flow Simulation — domain-scoped, read-only
+    |--------------------------------------------------------------------------
+    | Walks the dialplan tree starting from a given DID at a given timestamp
+    | and returns the active branch + every alternative. Dedicated throttle
+    | because each simulation walks several tables per call.
+    */
+    Route::middleware(['user.authorize:call_flow_simulate', 'throttle:call-flow-simulate'])->group(function () {
+        Route::get('/domains/{domain_uuid}/call-flow/simulate', [CallFlowSimulationController::class, 'simulate'])
+            ->name('api.v1.call-flow.simulate');
+    });
+
+    /*
+    |--------------------------------------------------------------------------
+    | Call Flow Simulation — global (cross-domain, admin)
+    |--------------------------------------------------------------------------
+    */
+    Route::middleware(['user.authorize:call_flow_simulate_all_domains', 'throttle:call-flow-simulate'])->group(function () {
+        Route::get('/call-flow/simulate', [CallFlowSimulationController::class, 'globalSimulate'])
+            ->name('api.v1.call-flow.global.simulate');
+    });
 });

--- a/tests/Feature/Api/V1/CallFlow/CallFlowRouteProtectionTest.php
+++ b/tests/Feature/Api/V1/CallFlow/CallFlowRouteProtectionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature\Api\V1\CallFlow;
+
+use Tests\TestCase;
+
+/**
+ * Route-level middleware smoke tests. End-to-end simulation with a seeded
+ * tenant is exercised via the Ansible-deployed staging host after merge;
+ * these cover the auth chain so an unauthenticated caller can't reach the
+ * controller.
+ */
+class CallFlowRouteProtectionTest extends TestCase
+{
+    private const DOMAIN = '00000000-0000-0000-0000-000000000001';
+
+    public function test_tenant_simulate_requires_authentication(): void
+    {
+        $this->getJson('/api/v1/domains/' . self::DOMAIN . '/call-flow/simulate?phone_number=%2B441225800810')
+            ->assertStatus(401);
+    }
+
+    public function test_global_simulate_requires_authentication(): void
+    {
+        $this->getJson('/api/v1/call-flow/simulate?domain_uuid=' . self::DOMAIN . '&phone_number=%2B441225800810')
+            ->assertStatus(401);
+    }
+}

--- a/tests/Unit/CallFlow/BusinessHoursEvaluatorTest.php
+++ b/tests/Unit/CallFlow/BusinessHoursEvaluatorTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Tests\Unit\CallFlow;
+
+use App\Models\BusinessHour;
+use App\Models\BusinessHourHoliday;
+use App\Models\BusinessHourPeriod;
+use App\Services\CallFlow\BusinessHoursEvaluator;
+use DateTimeImmutable;
+use DateTimeZone;
+use Illuminate\Database\Eloquent\Collection;
+use Tests\TestCase;
+
+class BusinessHoursEvaluatorTest extends TestCase
+{
+    private BusinessHoursEvaluator $evaluator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->evaluator = new BusinessHoursEvaluator();
+    }
+
+    private function period(int $dow, string $start, string $end): BusinessHourPeriod
+    {
+        $p = new BusinessHourPeriod();
+        $p->day_of_week = $dow;
+        $p->start_time = $start;
+        $p->end_time = $end;
+        return $p;
+    }
+
+    private function buildBusinessHour(array $periods = [], array $holidays = [], string $tz = 'UTC'): BusinessHour
+    {
+        $bh = new BusinessHour();
+        $bh->timezone = $tz;
+        $bh->setRelation('periods', new Collection($periods));
+        $bh->setRelation('holidays', new Collection($holidays));
+        return $bh;
+    }
+
+    private function at(string $iso, string $tz = 'UTC'): DateTimeImmutable
+    {
+        return new DateTimeImmutable($iso, new DateTimeZone($tz));
+    }
+
+    public function test_weekday_9_to_5_in_hours(): void
+    {
+        // FreeSWITCH day_of_week: 1=Sun…7=Sat. Monday=2, Friday=6.
+        $bh = $this->buildBusinessHour([
+            $this->period(2, '09:00', '17:00'),
+            $this->period(3, '09:00', '17:00'),
+            $this->period(4, '09:00', '17:00'),
+            $this->period(5, '09:00', '17:00'),
+            $this->period(6, '09:00', '17:00'),
+        ]);
+        // 2026-04-23 is Thu (wday=5 FreeSWITCH).
+        $r = $this->evaluator->evaluate($bh, $this->at('2026-04-23T10:00:00Z'));
+        $this->assertTrue($r['is_in_hours']);
+        $this->assertNotNull($r['period']);
+    }
+
+    public function test_weekend_is_out_of_hours(): void
+    {
+        $bh = $this->buildBusinessHour([
+            $this->period(2, '09:00', '17:00'),
+        ]);
+        // Sat 2026-04-25.
+        $r = $this->evaluator->evaluate($bh, $this->at('2026-04-25T10:00:00Z'));
+        $this->assertFalse($r['is_in_hours']);
+        $this->assertNull($r['period']);
+    }
+
+    public function test_evening_is_out_of_hours(): void
+    {
+        $bh = $this->buildBusinessHour([
+            $this->period(5, '09:00', '17:00'),
+        ]);
+        $r = $this->evaluator->evaluate($bh, $this->at('2026-04-23T19:00:00Z'));
+        $this->assertFalse($r['is_in_hours']);
+    }
+
+    public function test_timezone_shifts_boundary(): void
+    {
+        // 09:00 London BST = 08:00 UTC.
+        $bh = $this->buildBusinessHour(
+            [$this->period(5, '09:00', '17:00')],
+            [],
+            'Europe/London',
+        );
+
+        // 08:30 UTC in July = 09:30 BST — in hours.
+        $r = $this->evaluator->evaluate($bh, $this->at('2026-07-16T08:30:00Z'));
+        $this->assertTrue($r['is_in_hours']);
+
+        // 07:30 UTC = 08:30 BST — still out.
+        $r = $this->evaluator->evaluate($bh, $this->at('2026-07-16T07:30:00Z'));
+        $this->assertFalse($r['is_in_hours']);
+    }
+
+    public function test_overnight_period_wraps(): void
+    {
+        // 22:00 → 02:00 next day.
+        $bh = $this->buildBusinessHour([
+            $this->period(5, '22:00', '02:00'),
+        ]);
+        // 2026-04-23 is Thursday = FS wday 5; 23:00 should match.
+        $r = $this->evaluator->evaluate($bh, $this->at('2026-04-23T23:00:00Z'));
+        $this->assertTrue($r['is_in_hours']);
+    }
+
+    public function test_single_date_holiday_closes(): void
+    {
+        $holiday = new BusinessHourHoliday();
+        $holiday->holiday_type = 'single_date';
+        $holiday->start_date = \Carbon\Carbon::parse('2026-04-23');
+        $holiday->description = 'Test Holiday';
+
+        $bh = $this->buildBusinessHour(
+            [$this->period(5, '09:00', '17:00')],
+            [$holiday],
+        );
+
+        $r = $this->evaluator->evaluate($bh, $this->at('2026-04-23T10:00:00Z'));
+        $this->assertFalse($r['is_in_hours']);
+        $this->assertNotNull($r['holiday']);
+    }
+
+    public function test_recurring_holiday_emits_warning(): void
+    {
+        $holiday = new BusinessHourHoliday();
+        $holiday->holiday_type = 'us_holiday';
+        $holiday->description = 'Thanksgiving';
+
+        $bh = $this->buildBusinessHour(
+            [$this->period(5, '09:00', '17:00')],
+            [$holiday],
+        );
+
+        $r = $this->evaluator->evaluate($bh, $this->at('2026-04-23T10:00:00Z'));
+        $this->assertTrue($r['is_in_hours']);
+        $this->assertNotEmpty($r['warnings']);
+    }
+}

--- a/tests/Unit/CallFlow/CallFlowMermaidRendererTest.php
+++ b/tests/Unit/CallFlow/CallFlowMermaidRendererTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Unit\CallFlow;
+
+use App\Data\Api\V1\CallFlow\CallFlowBranchData;
+use App\Data\Api\V1\CallFlow\CallFlowNodeData;
+use App\Data\Api\V1\CallFlow\CallFlowSimulationData;
+use App\Services\CallFlow\CallFlowMermaidRenderer;
+use Tests\TestCase;
+
+class CallFlowMermaidRendererTest extends TestCase
+{
+    public function test_renders_simple_tree(): void
+    {
+        $vm = new CallFlowNodeData('n3', 'voicemail', 'Voicemail 810', null, '810', null, []);
+        $bh = new CallFlowNodeData('n2', 'business_hours', 'Business Hours: Main', null, '9200', null, [
+            new CallFlowBranchData('after_hours', 'after hours', true, $vm),
+        ]);
+        $root = new CallFlowNodeData('n1', 'inbound_did', 'Inbound +441225800810', null, null, null, [
+            new CallFlowBranchData('enter', null, true, $bh),
+        ]);
+        $sim = new CallFlowSimulationData(
+            object: 'call_flow_simulation',
+            url: '/x',
+            domain_uuid: 'd',
+            domain_name: 'test',
+            phone_number: '+441225800810',
+            evaluated_at: '2026-04-23T19:00:00Z',
+            timezone: 'Europe/London',
+            tree: $root,
+            warnings: [],
+        );
+
+        $out = (new CallFlowMermaidRenderer())->render($sim);
+
+        $this->assertStringStartsWith("flowchart LR\n", $out);
+        $this->assertStringContainsString('n1["Inbound +441225800810"]', $out);
+        $this->assertStringContainsString('n3["Voicemail 810 (810)"]', $out);
+        $this->assertStringContainsString('n1 ==>|enter| n2', $out);
+        $this->assertStringContainsString('n2 ==>|after hours| n3', $out);
+    }
+
+    public function test_pipe_in_label_is_escaped(): void
+    {
+        $node = new CallFlowNodeData('n1', 'inbound_did', 'a|b|c', null, null, null, []);
+        $sim = new CallFlowSimulationData(
+            'call_flow_simulation', '/x', 'd', null, '+1', 'now', 'UTC', $node, [],
+        );
+        $out = (new CallFlowMermaidRenderer())->render($sim);
+        $this->assertStringContainsString('a/b/c', $out);
+    }
+
+    public function test_inactive_branches_use_thin_arrow(): void
+    {
+        $child = new CallFlowNodeData('n2', 'hangup', 'Hang up', null, null, null, []);
+        $root = new CallFlowNodeData('n1', 'inbound_did', 'In', null, null, null, [
+            new CallFlowBranchData('press_1', 'press 1', false, $child),
+        ]);
+        $sim = new CallFlowSimulationData(
+            'call_flow_simulation', '/x', 'd', null, '+1', 'now', 'UTC', $root, [],
+        );
+        $out = (new CallFlowMermaidRenderer())->render($sim);
+        $this->assertStringContainsString('n1 -->|press 1| n2', $out);
+    }
+}

--- a/tests/Unit/CallFlow/RingGroupStrategyEvaluatorTest.php
+++ b/tests/Unit/CallFlow/RingGroupStrategyEvaluatorTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Tests\Unit\CallFlow;
+
+use App\Models\RingGroups;
+use App\Models\RingGroupsDestinations;
+use App\Services\CallFlow\CallFlowContext;
+use App\Services\CallFlow\RingGroupStrategyEvaluator;
+use DateTimeImmutable;
+use Illuminate\Database\Eloquent\Collection;
+use Tests\TestCase;
+
+class RingGroupStrategyEvaluatorTest extends TestCase
+{
+    private RingGroupStrategyEvaluator $evaluator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->evaluator = new RingGroupStrategyEvaluator();
+    }
+
+    private function ctx(): CallFlowContext
+    {
+        return new CallFlowContext(
+            domainUuid: '00000000-0000-0000-0000-000000000000',
+            domainName: 'test.example',
+            at: new DateTimeImmutable('2026-04-23T10:00:00Z'),
+            timezone: 'UTC',
+        );
+    }
+
+    private function member(string $ext, int $delay = 0, int $timeout = 0): RingGroupsDestinations
+    {
+        // Bypass constructor to skip Session::get() in RingGroupsDestinations::__construct
+        $m = (new \ReflectionClass(RingGroupsDestinations::class))->newInstanceWithoutConstructor();
+        $m->destination_number = $ext;
+        $m->destination_delay = $delay;
+        $m->destination_timeout = $timeout;
+        return $m;
+    }
+
+    private function group(string $strategy, array $members, int $timeout = 30): RingGroups
+    {
+        $g = new RingGroups();
+        $g->ring_group_uuid = '00000000-0000-0000-0000-000000000001';
+        $g->domain_uuid = '00000000-0000-0000-0000-000000000000';
+        $g->ring_group_name = 'Test';
+        $g->ring_group_extension = '9000';
+        $g->ring_group_strategy = $strategy;
+        $g->ring_group_call_timeout = $timeout;
+        $g->ring_group_timeout_app = '';
+        $g->ring_group_timeout_data = '';
+        $g->setRelation('destinations', new Collection($members));
+        return $g;
+    }
+
+    public function test_simultaneous_emits_single_node_with_members(): void
+    {
+        $g = $this->group('simultaneous', [
+            $this->member('201'),
+            $this->member('202'),
+        ]);
+        $ctx = $this->ctx();
+
+        // walker never called because no exit configured
+        $node = $this->evaluator->expand($g, $ctx, fn ($opt) => throw new \AssertionError('should not recurse'));
+
+        $this->assertSame('ring_group', $node->type);
+        $this->assertSame('simultaneous', $node->metadata['strategy']);
+        $this->assertCount(2, $node->metadata['members']);
+        $this->assertSame([], $node->branches);
+    }
+
+    public function test_sequential_chains_members(): void
+    {
+        $g = $this->group('sequence', [
+            $this->member('201'),
+            $this->member('202'),
+            $this->member('203'),
+        ]);
+        $ctx = $this->ctx();
+
+        $node = $this->evaluator->expand($g, $ctx, fn ($opt) => throw new \AssertionError('no exit configured'));
+
+        $this->assertSame('ring_group', $node->type);
+        $this->assertCount(1, $node->branches);
+        $this->assertSame('enter', $node->branches[0]->condition);
+
+        // first member → second → third
+        $first = $node->branches[0]->child;
+        $this->assertSame('ring_group_member', $first->type);
+        $this->assertSame('201', $first->extension);
+        $this->assertCount(1, $first->branches);
+        $this->assertSame('member_next', $first->branches[0]->condition);
+
+        $second = $first->branches[0]->child;
+        $this->assertSame('202', $second->extension);
+
+        $third = $second->branches[0]->child;
+        $this->assertSame('203', $third->extension);
+        // no exit configured, so tail has no further branch
+        $this->assertSame([], $third->branches);
+    }
+
+    public function test_random_strategy_attaches_warning(): void
+    {
+        $g = $this->group('random', [$this->member('201')]);
+        $ctx = $this->ctx();
+
+        $this->evaluator->expand($g, $ctx, fn ($opt) => throw new \AssertionError('not called'));
+
+        $this->assertNotEmpty($ctx->warnings);
+        $this->assertStringContainsString('nondeterministic', $ctx->warnings[0]);
+    }
+
+    public function test_external_sip_member(): void
+    {
+        $g = $this->group('sequence', [
+            $this->member('sip:alice@example.com'),
+        ]);
+        $ctx = $this->ctx();
+
+        $node = $this->evaluator->expand($g, $ctx, fn ($opt) => throw new \AssertionError('not called'));
+
+        $first = $node->branches[0]->child;
+        $this->assertSame('external', $first->metadata['target_kind']);
+    }
+}

--- a/tests/Unit/CallFlow/TimeConditionEvaluatorTest.php
+++ b/tests/Unit/CallFlow/TimeConditionEvaluatorTest.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Tests\Unit\CallFlow;
+
+use App\Services\CallFlow\TimeConditionEvaluator;
+use App\Services\CallFlow\TimeConditionParseException;
+use DateTimeImmutable;
+use DateTimeZone;
+use Tests\TestCase;
+
+class TimeConditionEvaluatorTest extends TestCase
+{
+    private TimeConditionEvaluator $evaluator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->evaluator = new TimeConditionEvaluator();
+    }
+
+    private function at(string $iso, string $tz = 'UTC'): DateTimeImmutable
+    {
+        return new DateTimeImmutable($iso, new DateTimeZone($tz));
+    }
+
+    private function dialplan(string $body): string
+    {
+        return <<<XML
+<extension name="test">
+  $body
+</extension>
+XML;
+    }
+
+    public function test_hour_range_matches(): void
+    {
+        $xml = $this->dialplan('
+            <condition hour="9-17">
+              <action application="transfer" data="201 XML example.com"/>
+            </condition>
+            <condition>
+              <action application="transfer" data="202 XML example.com"/>
+            </condition>
+        ');
+
+        // 2026-04-23T10:00 UTC is Thu 10:00 — in the range.
+        $result = $this->evaluator->evaluate($xml, $this->at('2026-04-23T10:00:00Z'), 'UTC');
+        $this->assertSame(['destination_app' => 'transfer', 'destination_data' => '201 XML example.com'], $result['matched_action']);
+        $this->assertSame(['destination_app' => 'transfer', 'destination_data' => '202 XML example.com'], $result['fallback_action']);
+    }
+
+    public function test_hour_range_falls_through_to_fallback(): void
+    {
+        $xml = $this->dialplan('
+            <condition hour="9-17">
+              <action application="transfer" data="201 XML example.com"/>
+            </condition>
+            <condition>
+              <action application="transfer" data="*99201 XML example.com"/>
+            </condition>
+        ');
+
+        // 19:00 is outside 9-17 — no match; caller uses fallback.
+        $result = $this->evaluator->evaluate($xml, $this->at('2026-04-23T19:00:00Z'), 'UTC');
+        $this->assertNull($result['matched_action']);
+        $this->assertSame('*99201 XML example.com', $result['fallback_action']['destination_data']);
+    }
+
+    public function test_multiple_time_fields_must_all_match(): void
+    {
+        $xml = $this->dialplan('
+            <condition hour="9-17" wday="2-6">
+              <action application="transfer" data="201 XML example.com"/>
+            </condition>
+        ');
+
+        // Thu = FreeSWITCH wday 5, 10:00 — both match.
+        $thu = $this->evaluator->evaluate($xml, $this->at('2026-04-23T10:00:00Z'), 'UTC');
+        $this->assertNotNull($thu['matched_action']);
+
+        // Sun = FreeSWITCH wday 1, 10:00 — wday fails.
+        $sun = $this->evaluator->evaluate($xml, $this->at('2026-04-26T10:00:00Z'), 'UTC');
+        $this->assertNull($sun['matched_action']);
+    }
+
+    public function test_timezone_is_honoured(): void
+    {
+        $xml = $this->dialplan('
+            <condition hour="9-17">
+              <action application="transfer" data="201 XML example.com"/>
+            </condition>
+        ');
+
+        // 03:00 UTC = 04:00 BST in Europe/London on this date — outside 9-17.
+        $result = $this->evaluator->evaluate($xml, $this->at('2026-07-15T03:00:00Z'), 'Europe/London');
+        $this->assertNull($result['matched_action']);
+
+        // 10:00 UTC = 11:00 BST — inside.
+        $result = $this->evaluator->evaluate($xml, $this->at('2026-07-15T10:00:00Z'), 'Europe/London');
+        $this->assertNotNull($result['matched_action']);
+    }
+
+    public function test_comma_list_and_single_value(): void
+    {
+        $xml = $this->dialplan('
+            <condition wday="2,4,6">
+              <action application="transfer" data="a XML example.com"/>
+            </condition>
+            <condition wday="7">
+              <action application="transfer" data="b XML example.com"/>
+            </condition>
+        ');
+
+        // Sat = FreeSWITCH wday 7 → second condition.
+        $result = $this->evaluator->evaluate($xml, $this->at('2026-04-25T10:00:00Z'), 'UTC');
+        $this->assertSame('b XML example.com', $result['matched_action']['destination_data']);
+    }
+
+    public function test_time_of_day_with_overnight_wrap(): void
+    {
+        $xml = $this->dialplan('
+            <condition time-of-day="22:00-06:00">
+              <action application="transfer" data="night XML example.com"/>
+            </condition>
+        ');
+
+        $this->assertNotNull($this->evaluator->evaluate($xml, $this->at('2026-04-23T23:30:00Z'), 'UTC')['matched_action']);
+        $this->assertNotNull($this->evaluator->evaluate($xml, $this->at('2026-04-23T04:30:00Z'), 'UTC')['matched_action']);
+        $this->assertNull($this->evaluator->evaluate($xml, $this->at('2026-04-23T12:00:00Z'), 'UTC')['matched_action']);
+    }
+
+    public function test_date_time_range(): void
+    {
+        $xml = $this->dialplan('
+            <condition date-time="2026-04-20 00:00~2026-04-24 23:59">
+              <action application="transfer" data="closed XML example.com"/>
+            </condition>
+        ');
+
+        $this->assertNotNull($this->evaluator->evaluate($xml, $this->at('2026-04-22T12:00:00Z'), 'UTC')['matched_action']);
+        $this->assertNull($this->evaluator->evaluate($xml, $this->at('2026-05-01T12:00:00Z'), 'UTC')['matched_action']);
+    }
+
+    public function test_minute_of_day_boundary(): void
+    {
+        $xml = $this->dialplan('
+            <condition minute-of-day="540-1020">
+              <action application="transfer" data="x XML example.com"/>
+            </condition>
+        ');
+        // 09:00 = 9*60+0+1 = 541 — in range.
+        $this->assertNotNull($this->evaluator->evaluate($xml, $this->at('2026-04-23T09:00:00Z'), 'UTC')['matched_action']);
+        // 17:00 = 17*60+0+1 = 1021 — out.
+        $this->assertNull($this->evaluator->evaluate($xml, $this->at('2026-04-23T17:00:00Z'), 'UTC')['matched_action']);
+    }
+
+    public function test_set_and_export_actions_are_skipped(): void
+    {
+        $xml = $this->dialplan('
+            <condition hour="0-23">
+              <action application="set" data="foo=bar"/>
+              <action application="export" data="baz=qux"/>
+              <action application="transfer" data="201 XML example.com"/>
+            </condition>
+        ');
+        $result = $this->evaluator->evaluate($xml, $this->at('2026-04-23T10:00:00Z'), 'UTC');
+        $this->assertSame('transfer', $result['matched_action']['destination_app']);
+        $this->assertSame('201 XML example.com', $result['matched_action']['destination_data']);
+    }
+
+    public function test_malformed_xml_throws(): void
+    {
+        $this->expectException(TimeConditionParseException::class);
+        $this->evaluator->evaluate('<not valid', $this->at('2026-04-23T10:00:00Z'), 'UTC');
+    }
+}


### PR DESCRIPTION
## Summary

Adds a read-only \`GET /api/v1/.../call-flow/simulate\` endpoint that walks the dialplan tree starting from a given DID at a given timestamp and returns a structured tree of every branch a call could take, plus which branch is active right now.

The complement of the CDR API: where CDR answers _"what did happen?"_, this answers _"what should happen if I dial X at time T?"_.

### Endpoints

\`\`\`
GET /api/v1/domains/{domain_uuid}/call-flow/simulate   # tenant
GET /api/v1/call-flow/simulate                          # cross-domain admin
\`\`\`

Query params: \`phone_number\` (E.164 or national), \`at\` (optional ISO ts; defaults to now), \`max_depth\` (1–50, default 20), \`format=json|mermaid\`.

### How it works

The simulator (\`app/Services/CallFlow/CallFlowSimulator.php\`) starts from the matched \`v_destinations\` row, decodes \`destination_actions\` via the existing \`CallRoutingOptionsService\`, and recursively expands each destination type. Branching evaluators:

- **business_hours** — resolves the active period in the tenant's timezone, applies single-date / date-range / recurring holidays. Emits \`in_hours\` / \`after_hours\` branches with the active flag.
- **time_conditions** — parses FreeSWITCH \`<condition>\` XML (hour, wday, mday, minute-of-day, time-of-day, date-time, etc.) and emits \`time_match\` / \`time_no_match\`.
- **ivrs** — one branch per \`IvrMenuOption\` (press_0..9, \`*\`, \`#\`) plus a timeout branch via \`ivr_menu_exit_app\`+\`data\`.
- **ring_groups** — strategy-aware: sequence/rollover chains members; simultaneous/enterprise emits one node with member metadata; random attaches a nondeterminism warning.
- **extensions** — \`forward_all\` short-circuits; otherwise busy + no_answer branches, defaulting no_answer to personal voicemail.

Terminal node types: voicemail, hangup, external, ai_agent, conference, contact_center.

Cycle + depth guard on every walk step (tracks \`type:uuid\` tuples).

\`format=mermaid\` renders the tree as a \`flowchart LR\` for human inspection or embedding in tickets / docs.

### Auth

Two new permissions:
- \`call_flow_simulate\` — required for tenant route
- \`call_flow_simulate_all_domains\` — required for global route

New \`throttle:call-flow-simulate\` limiter caps each token at 10/min so an agent-tool loop can't hammer the DB.

### Tests

Unit tests for each evaluator + the Mermaid renderer; feature test covers route-level auth. Run via \`php artisan test --filter=CallFlow\`.

## Why community-friendly

- Self-contained: only adds new files plus minimal additions to \`routes/api_v1.php\`, \`RouteServiceProvider\`, and \`DatabaseSeeder\`.
- No external services, no provider-specific code, no Voxra branding.
- Strong test coverage on the evaluators and renderer.

## Test plan

- [ ] \`php artisan migrate && php artisan db:seed\` — verify the two new permissions seed.
- [ ] \`php artisan test --filter=CallFlow\` — all green.
- [ ] Hit the tenant endpoint with a valid DID for a domain that has a business-hours dialplan; verify the JSON tree shows in_hours / after_hours branches with the correct one marked \`active: true\`.
- [ ] Hit \`?format=mermaid\` — verify the response is plain text and renders in any Mermaid viewer.
- [ ] Hit the endpoint without the new permission — confirm 403.

## Notes for reviewers

- I dropped the tenant-vs-global token scope middleware that exists in our fork (\`cdr.scope\`) and just gate via permissions here, to keep this PR self-contained. If you would like that scoping pattern added, happy to do it as a follow-up alongside an analogous CDR PR.
- The simulator is designed to be extended: adding a new destination type means one branch in \`CallFlowSimulator::walk()\` plus an optional dedicated evaluator class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Updates (June 2026)

Rebased onto current main to resolve conflicts.
