### PR TITLE
Add v1 REST API endpoints for users

### DIFF
--- a/app/Data/Api/V1/UserData.php
+++ b/app/Data/Api/V1/UserData.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Data\Api\V1;
+
+use App\Models\User;
+use Spatie\LaravelData\Data;
+use Spatie\LaravelData\Optional;
+
+class UserData extends Data
+{
+    public function __construct(
+        public string $user_uuid,
+        public string $object,
+        public string $domain_uuid,
+        public string $username,
+        public ?string $user_email,
+        public ?string $first_name,
+        public ?string $last_name,
+        public ?string $name_formatted,
+        public bool $user_enabled,
+        public bool $is_domain_admin,
+        public string|Optional|null $language = new Optional(),
+        public string|Optional|null $time_zone = new Optional(),
+        public ?string $created_at = null,
+    ) {}
+
+    public static function fromModel(User $user): self
+    {
+        $isAdmin = false;
+        if ($user->relationLoaded('user_groups') || $user->user_groups) {
+            $isAdmin = $user->user_groups->contains(function ($ug) {
+                return strtolower((string) $ug->group_name) === 'admin'
+                    || strtolower((string) $ug->group_name) === 'superadmin';
+            });
+        }
+
+        return new self(
+            user_uuid: (string) $user->user_uuid,
+            object: 'user',
+            domain_uuid: (string) $user->domain_uuid,
+            username: (string) $user->username,
+            user_email: $user->user_email,
+            first_name: $user->first_name ?: null,
+            last_name: $user->last_name ?: null,
+            name_formatted: $user->name_formatted,
+            user_enabled: self::textBool($user->user_enabled),
+            is_domain_admin: $isAdmin,
+            language: $user->language,
+            time_zone: $user->time_zone,
+            created_at: $user->add_date ? (string) $user->add_date : null,
+        );
+    }
+
+    private static function textBool($value): bool
+    {
+        if (is_bool($value)) return $value;
+        if ($value === null || $value === '') return false;
+        $v = strtolower(trim((string) $value));
+        return in_array($v, ['true', 't', '1', 'yes', 'y', 'on'], true);
+    }
+}

--- a/app/Http/Controllers/Api/V1/UserController.php
+++ b/app/Http/Controllers/Api/V1/UserController.php
@@ -1,0 +1,516 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Data\Api\V1\DeletedResponseData;
+use App\Data\Api\V1\UserData;
+use App\Exceptions\ApiException;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\StoreUserRequest;
+use App\Http\Requests\Api\V1\UpdateUserRequest;
+use App\Models\Domain;
+use App\Models\Groups;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Spatie\QueryBuilder\QueryBuilder;
+
+class UserController extends Controller
+{
+    private const ADMIN_GROUP_NAME = 'admin';
+
+    /**
+     * List users
+     *
+     * Returns users belonging to the specified domain.
+     *
+     * Access rules:
+     * - Caller must have access to the target domain (domain scope).
+     * - Caller must have the `user_view` permission.
+     *
+     * Pagination (cursor-based):
+     * - Both `limit` and `starting_after` are optional.
+     * - If `limit` is not provided, it defaults to 50.
+     * - If `starting_after` is not provided, results start from the beginning.
+     * - If `has_more` is true, request the next page by passing `starting_after`
+     *   equal to the last item's `user_uuid` from the previous response.
+     *
+     * @group Users
+     * @authenticated
+     *
+     * @urlParam domain_uuid string required The domain UUID. Example: 4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b
+     * @queryParam limit integer Optional. Number of results (1-200). Defaults to 50. Example: 50
+     * @queryParam starting_after string Optional. Return results after this user UUID (cursor). Example: c0ec8113-aa15-40ac-8437-47185dd9dcf4
+     *
+     * @response 200 scenario="Success" {
+     *   "object": "list",
+     *   "url": "/api/v1/domains/4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b/users",
+     *   "has_more": false,
+     *   "data": [
+     *     {
+     *       "user_uuid": "9c6c2a5e-1ab1-4a0e-8d7f-cb8b2a4d111e",
+     *       "object": "user",
+     *       "domain_uuid": "4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b",
+     *       "username": "ada_lovelace",
+     *       "user_email": "ada.lovelace@example.com",
+     *       "first_name": "Ada",
+     *       "last_name": "Lovelace",
+     *       "name_formatted": "Ada Lovelace",
+     *       "user_enabled": true,
+     *       "is_domain_admin": true,
+     *       "language": "en-us",
+     *       "time_zone": "Europe/London",
+     *       "created_at": "2026-04-08 12:34:56"
+     *     }
+     *   ]
+     * }
+     *
+     * @response 400 scenario="Invalid domain UUID" {"error":{"type":"invalid_request_error","message":"Invalid domain UUID.","code":"invalid_request","param":"domain_uuid"}}
+     * @response 400 scenario="Invalid starting_after UUID" {"error":{"type":"invalid_request_error","message":"Invalid starting_after UUID.","code":"invalid_request","param":"starting_after"}}
+     * @response 401 scenario="Unauthenticated" {"error":{"type":"authentication_error","message":"Unauthenticated.","code":"unauthenticated"}}
+     * @response 404 scenario="Domain not found" {"error":{"type":"invalid_request_error","message":"Domain not found.","code":"resource_missing","param":"domain_uuid"}}
+     */
+    public function index(Request $request, string $domain_uuid)
+    {
+        $this->requireAuth($request);
+        $this->validateDomainUuid($domain_uuid);
+        $this->loadDomainOrFail($domain_uuid);
+
+        $limit = (int) $request->input('limit', 50);
+        $limit = max(1, min(200, $limit));
+
+        $startingAfter = (string) $request->input('starting_after', '');
+
+        $query = QueryBuilder::for(User::class)
+            ->where('domain_uuid', $domain_uuid)
+            ->with(['user_adv_fields', 'user_groups', 'settings'])
+            ->defaultSort('user_uuid')
+            ->reorder('user_uuid')
+            ->limit($limit + 1);
+
+        if ($startingAfter !== '') {
+            if (! preg_match('/^[0-9a-fA-F-]{36}$/', $startingAfter)) {
+                throw new ApiException(400, 'invalid_request_error', 'Invalid starting_after UUID.', 'invalid_request', 'starting_after');
+            }
+            $query->where('user_uuid', '>', $startingAfter);
+        }
+
+        $rows = $query->get();
+        $hasMore = $rows->count() > $limit;
+        $rows = $rows->take($limit);
+
+        $data = $rows->map(fn (User $u) => UserData::fromModel($u));
+
+        return response()->json([
+            'object'   => 'list',
+            'url'      => "/api/v1/domains/{$domain_uuid}/users",
+            'has_more' => $hasMore,
+            'data'     => $data,
+        ], 200);
+    }
+
+    /**
+     * Retrieve a user
+     *
+     * Returns a single user from the specified domain.
+     *
+     * Access rules:
+     * - Caller must have access to the target domain (domain scope).
+     * - Caller must have the `user_view` permission.
+     *
+     * @group Users
+     * @authenticated
+     *
+     * @urlParam domain_uuid string required The domain UUID. Example: 4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b
+     * @urlParam user_uuid string required The user UUID. Example: 9c6c2a5e-1ab1-4a0e-8d7f-cb8b2a4d111e
+     *
+     * @response 200 scenario="Success" {
+     *   "user_uuid": "9c6c2a5e-1ab1-4a0e-8d7f-cb8b2a4d111e",
+     *   "object": "user",
+     *   "domain_uuid": "4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b",
+     *   "username": "ada_lovelace",
+     *   "user_email": "ada.lovelace@example.com",
+     *   "first_name": "Ada",
+     *   "last_name": "Lovelace",
+     *   "name_formatted": "Ada Lovelace",
+     *   "user_enabled": true,
+     *   "is_domain_admin": true,
+     *   "language": "en-us",
+     *   "time_zone": "Europe/London",
+     *   "created_at": "2026-04-08 12:34:56"
+     * }
+     *
+     * @response 400 scenario="Invalid domain UUID" {"error":{"type":"invalid_request_error","message":"Invalid domain UUID.","code":"invalid_request","param":"domain_uuid"}}
+     * @response 400 scenario="Invalid user UUID" {"error":{"type":"invalid_request_error","message":"Invalid user UUID.","code":"invalid_request","param":"user_uuid"}}
+     * @response 401 scenario="Unauthenticated" {"error":{"type":"authentication_error","message":"Unauthenticated.","code":"unauthenticated"}}
+     * @response 404 scenario="Domain not found" {"error":{"type":"invalid_request_error","message":"Domain not found.","code":"resource_missing","param":"domain_uuid"}}
+     * @response 404 scenario="User not found" {"error":{"type":"invalid_request_error","message":"User not found.","code":"resource_missing","param":"user_uuid"}}
+     */
+    public function show(Request $request, string $domain_uuid, string $user_uuid)
+    {
+        $this->requireAuth($request);
+        $this->validateDomainUuid($domain_uuid);
+        $this->validateUserUuid($user_uuid);
+        $this->loadDomainOrFail($domain_uuid);
+
+        $user = $this->loadUserOrFail($domain_uuid, $user_uuid);
+
+        return response()->json(UserData::fromModel($user)->toArray(), 200);
+    }
+
+    /**
+     * Create a user
+     *
+     * Creates a new user in the specified domain. Optionally promotes the user
+     * to a domain administrator by adding them to the global `admin` group with
+     * a `v_user_groups` row scoped to this domain.
+     *
+     * @group Users
+     * @authenticated
+     *
+     * @urlParam domain_uuid string required The domain UUID. Example: 4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b
+     *
+     * @response 201 scenario="Created" {
+     *   "user_uuid": "9c6c2a5e-1ab1-4a0e-8d7f-cb8b2a4d111e",
+     *   "object": "user",
+     *   "domain_uuid": "4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b",
+     *   "username": "ada_lovelace",
+     *   "user_email": "ada.lovelace@example.com",
+     *   "first_name": "Ada",
+     *   "last_name": "Lovelace",
+     *   "name_formatted": "Ada Lovelace",
+     *   "user_enabled": true,
+     *   "is_domain_admin": true,
+     *   "language": "en-us",
+     *   "time_zone": "Europe/London",
+     *   "created_at": "2026-04-08 12:34:56"
+     * }
+     *
+     * @response 400 scenario="Invalid domain UUID" {"error":{"type":"invalid_request_error","message":"Invalid domain UUID.","code":"invalid_request","param":"domain_uuid"}}
+     * @response 401 scenario="Unauthenticated" {"error":{"type":"authentication_error","message":"Unauthenticated.","code":"unauthenticated"}}
+     * @response 404 scenario="Domain not found" {"error":{"type":"invalid_request_error","message":"Domain not found.","code":"resource_missing","param":"domain_uuid"}}
+     * @response 422 scenario="Validation error" {"error":{"type":"invalid_request_error","message":"The given data was invalid.","code":"invalid_request","param":null,"details":{"user_email":["A user with this email already exists."]}}}
+     */
+    public function store(StoreUserRequest $request, string $domain_uuid)
+    {
+        $this->requireAuth($request);
+        $this->validateDomainUuid($domain_uuid);
+        $this->loadDomainOrFail($domain_uuid);
+
+        $validated = $request->validated();
+
+        try {
+            /** @var User $user */
+            $user = DB::transaction(function () use ($validated, $domain_uuid) {
+                $user = User::create([
+                    'username'     => (string) $validated['username'],
+                    'user_email'   => (string) $validated['user_email'],
+                    'password'     => Hash::make($validated['password']),
+                    'domain_uuid'  => $domain_uuid,
+                    'user_enabled' => $this->toTextBool($validated['user_enabled'] ?? true),
+                ]);
+
+                $user->user_adv_fields()->create([
+                    'first_name' => $validated['first_name'],
+                    'last_name'  => $validated['last_name'],
+                ]);
+
+                foreach (['language', 'time_zone'] as $field) {
+                    if (! array_key_exists($field, $validated)) {
+                        continue;
+                    }
+                    $user->settings()->create([
+                        'domain_uuid'              => $domain_uuid,
+                        'user_setting_category'    => 'domain',
+                        'user_setting_subcategory' => $field,
+                        'user_setting_name'        => $field === 'language' ? 'code' : 'name',
+                        'user_setting_value'       => $validated[$field],
+                        'user_setting_enabled'     => true,
+                    ]);
+                }
+
+                if (! empty($validated['is_domain_admin'])) {
+                    $this->assignAdminGroup($user, $domain_uuid);
+                }
+
+                return $user;
+            });
+
+            $user = $this->loadUserOrFail($domain_uuid, (string) $user->user_uuid);
+
+            return response()
+                ->json(UserData::fromModel($user)->toArray(), 201)
+                ->header('Location', "/api/v1/domains/{$domain_uuid}/users/{$user->user_uuid}");
+        } catch (ApiException $e) {
+            throw $e;
+        } catch (\Throwable $e) {
+            logger('API User store error: ' . $e->getMessage() . ' at ' . $e->getFile() . ':' . $e->getLine());
+            throw new ApiException(500, 'api_error', 'Internal server error.', 'internal_error');
+        }
+    }
+
+    /**
+     * Update a user
+     *
+     * Updates an existing user. All fields are optional; omitted fields are
+     * left unchanged. Toggling `is_domain_admin` adds or removes the user's
+     * `admin` group membership for this domain.
+     *
+     * @group Users
+     * @authenticated
+     *
+     * @urlParam domain_uuid string required The domain UUID. Example: 4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b
+     * @urlParam user_uuid string required The user UUID. Example: 9c6c2a5e-1ab1-4a0e-8d7f-cb8b2a4d111e
+     *
+     * @response 200 scenario="Success" {
+     *   "user_uuid": "9c6c2a5e-1ab1-4a0e-8d7f-cb8b2a4d111e",
+     *   "object": "user",
+     *   "domain_uuid": "4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b",
+     *   "username": "ada_lovelace",
+     *   "user_email": "ada.lovelace@example.com",
+     *   "first_name": "Ada",
+     *   "last_name": "Lovelace",
+     *   "name_formatted": "Ada Lovelace",
+     *   "user_enabled": true,
+     *   "is_domain_admin": false,
+     *   "language": "en-us",
+     *   "time_zone": "Europe/London",
+     *   "created_at": "2026-04-08 12:34:56"
+     * }
+     *
+     * @response 400 scenario="Invalid domain UUID" {"error":{"type":"invalid_request_error","message":"Invalid domain UUID.","code":"invalid_request","param":"domain_uuid"}}
+     * @response 400 scenario="Invalid user UUID" {"error":{"type":"invalid_request_error","message":"Invalid user UUID.","code":"invalid_request","param":"user_uuid"}}
+     * @response 401 scenario="Unauthenticated" {"error":{"type":"authentication_error","message":"Unauthenticated.","code":"unauthenticated"}}
+     * @response 404 scenario="Domain not found" {"error":{"type":"invalid_request_error","message":"Domain not found.","code":"resource_missing","param":"domain_uuid"}}
+     * @response 404 scenario="User not found" {"error":{"type":"invalid_request_error","message":"User not found.","code":"resource_missing","param":"user_uuid"}}
+     * @response 422 scenario="Validation error" {"error":{"type":"invalid_request_error","message":"The given data was invalid.","code":"invalid_request","param":null,"details":{"user_email":["A user with this email already exists."]}}}
+     */
+    public function update(UpdateUserRequest $request, string $domain_uuid, string $user_uuid)
+    {
+        $this->requireAuth($request);
+        $this->validateDomainUuid($domain_uuid);
+        $this->validateUserUuid($user_uuid);
+        $this->loadDomainOrFail($domain_uuid);
+
+        $user = $this->loadUserOrFail($domain_uuid, $user_uuid);
+        $validated = $request->validated();
+
+        try {
+            DB::transaction(function () use ($validated, $user, $domain_uuid) {
+                // Direct user fields
+                $userUpdates = [];
+                foreach (['username', 'user_email'] as $f) {
+                    if (array_key_exists($f, $validated)) {
+                        $userUpdates[$f] = $validated[$f];
+                    }
+                }
+                if (array_key_exists('user_enabled', $validated)) {
+                    $userUpdates['user_enabled'] = $this->toTextBool($validated['user_enabled']);
+                }
+                if (array_key_exists('password', $validated)) {
+                    $userUpdates['password'] = Hash::make($validated['password']);
+                }
+                if (! empty($userUpdates)) {
+                    $user->update($userUpdates);
+                }
+
+                // Names live on user_adv_fields
+                if (array_key_exists('first_name', $validated) || array_key_exists('last_name', $validated)) {
+                    $advUpdates = [];
+                    if (array_key_exists('first_name', $validated)) $advUpdates['first_name'] = $validated['first_name'];
+                    if (array_key_exists('last_name', $validated))  $advUpdates['last_name']  = $validated['last_name'];
+                    $user->user_adv_fields()->updateOrCreate(
+                        ['user_uuid' => $user->user_uuid],
+                        $advUpdates
+                    );
+                }
+
+                // Settings (language / time_zone)
+                foreach (['language', 'time_zone'] as $field) {
+                    if (! array_key_exists($field, $validated)) {
+                        continue;
+                    }
+                    $user->settings()->updateOrCreate(
+                        [
+                            'domain_uuid'              => $user->domain_uuid,
+                            'user_setting_category'    => 'domain',
+                            'user_setting_subcategory' => $field,
+                        ],
+                        [
+                            'user_setting_name'    => $field === 'language' ? 'code' : 'name',
+                            'user_setting_value'   => $validated[$field],
+                            'user_setting_enabled' => true,
+                        ]
+                    );
+                }
+
+                // Domain admin toggle
+                if (array_key_exists('is_domain_admin', $validated)) {
+                    if ($validated['is_domain_admin']) {
+                        $this->assignAdminGroup($user, $domain_uuid);
+                    } else {
+                        $this->removeAdminGroup($user, $domain_uuid);
+                    }
+                }
+            });
+
+            $user = $this->loadUserOrFail($domain_uuid, $user_uuid);
+
+            return response()->json(UserData::fromModel($user)->toArray(), 200);
+        } catch (ApiException $e) {
+            throw $e;
+        } catch (\Throwable $e) {
+            logger('API User update error: ' . $e->getMessage() . ' at ' . $e->getFile() . ':' . $e->getLine());
+            throw new ApiException(500, 'api_error', 'Internal server error.', 'internal_error');
+        }
+    }
+
+    /**
+     * Delete a user
+     *
+     * Permanently deletes a user, including their adv fields, settings, group
+     * memberships, and any cross-domain permission rows. This is irreversible.
+     *
+     * @group Users
+     * @authenticated
+     *
+     * @urlParam domain_uuid string required The domain UUID. Example: 4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b
+     * @urlParam user_uuid string required The user UUID. Example: 9c6c2a5e-1ab1-4a0e-8d7f-cb8b2a4d111e
+     *
+     * @response 200 scenario="Success" {"object":"user","uuid":"9c6c2a5e-1ab1-4a0e-8d7f-cb8b2a4d111e","deleted":true}
+     * @response 400 scenario="Invalid domain UUID" {"error":{"type":"invalid_request_error","message":"Invalid domain UUID.","code":"invalid_request","param":"domain_uuid"}}
+     * @response 400 scenario="Invalid user UUID" {"error":{"type":"invalid_request_error","message":"Invalid user UUID.","code":"invalid_request","param":"user_uuid"}}
+     * @response 401 scenario="Unauthenticated" {"error":{"type":"authentication_error","message":"Unauthenticated.","code":"unauthenticated"}}
+     * @response 404 scenario="User not found" {"error":{"type":"invalid_request_error","message":"User not found.","code":"resource_missing","param":"user_uuid"}}
+     */
+    public function destroy(Request $request, string $domain_uuid, string $user_uuid)
+    {
+        $this->requireAuth($request);
+        $this->validateDomainUuid($domain_uuid);
+        $this->validateUserUuid($user_uuid);
+        $this->loadDomainOrFail($domain_uuid);
+
+        $user = $this->loadUserOrFail($domain_uuid, $user_uuid);
+
+        try {
+            DB::transaction(function () use ($user) {
+                $user->user_groups()->delete();
+                $user->user_adv_fields()->delete();
+                $user->settings()->delete();
+                $user->domain_permissions()->delete();
+                $user->domain_group_permissions()->delete();
+                $user->delete();
+            });
+
+            $payload = DeletedResponseData::from([
+                'uuid'    => (string) $user_uuid,
+                'object'  => 'user',
+                'deleted' => true,
+            ]);
+
+            return response()->json($payload->toArray(), 200);
+        } catch (\Throwable $e) {
+            logger('API User delete error: ' . $e->getMessage() . ' at ' . $e->getFile() . ':' . $e->getLine());
+            throw new ApiException(500, 'api_error', 'Internal server error.', 'internal_error');
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // helpers
+    // -----------------------------------------------------------------------
+
+    private function requireAuth(Request $request): void
+    {
+        if (! $request->user()) {
+            throw new ApiException(401, 'authentication_error', 'Unauthenticated.', 'unauthenticated');
+        }
+    }
+
+    private function validateDomainUuid(string $domain_uuid): void
+    {
+        if (! preg_match('/^[0-9a-fA-F-]{36}$/', $domain_uuid)) {
+            throw new ApiException(400, 'invalid_request_error', 'Invalid domain UUID.', 'invalid_request', 'domain_uuid');
+        }
+    }
+
+    private function validateUserUuid(string $user_uuid): void
+    {
+        if (! preg_match('/^[0-9a-fA-F-]{36}$/', $user_uuid)) {
+            throw new ApiException(400, 'invalid_request_error', 'Invalid user UUID.', 'invalid_request', 'user_uuid');
+        }
+    }
+
+    private function loadDomainOrFail(string $domain_uuid): Domain
+    {
+        $domain = Domain::query()->where('domain_uuid', $domain_uuid)->first(['domain_uuid', 'domain_name']);
+        if (! $domain) {
+            throw new ApiException(404, 'invalid_request_error', 'Domain not found.', 'resource_missing', 'domain_uuid');
+        }
+        return $domain;
+    }
+
+    private function loadUserOrFail(string $domain_uuid, string $user_uuid): User
+    {
+        $user = User::query()
+            ->with(['user_adv_fields', 'user_groups', 'settings'])
+            ->where('domain_uuid', $domain_uuid)
+            ->where('user_uuid', $user_uuid)
+            ->first();
+
+        if (! $user) {
+            throw new ApiException(404, 'invalid_request_error', 'User not found.', 'resource_missing', 'user_uuid');
+        }
+        return $user;
+    }
+
+    private function assignAdminGroup(User $user, string $domain_uuid): void
+    {
+        // Already an admin in this domain? noop.
+        $exists = $user->user_groups()
+            ->where('group_name', self::ADMIN_GROUP_NAME)
+            ->where('domain_uuid', $domain_uuid)
+            ->exists();
+        if ($exists) {
+            return;
+        }
+
+        $group = Groups::query()
+            ->where('group_name', self::ADMIN_GROUP_NAME)
+            ->whereNull('domain_uuid')
+            ->first();
+
+        if (! $group) {
+            // Should never happen on a properly seeded install.
+            throw new ApiException(
+                500,
+                'api_error',
+                'Admin group is not configured on this server.',
+                'internal_error'
+            );
+        }
+
+        $user->user_groups()->create([
+            'group_uuid'  => $group->group_uuid,
+            'group_name'  => self::ADMIN_GROUP_NAME,
+            'domain_uuid' => $domain_uuid,
+        ]);
+    }
+
+    private function removeAdminGroup(User $user, string $domain_uuid): void
+    {
+        $user->user_groups()
+            ->where('group_name', self::ADMIN_GROUP_NAME)
+            ->where('domain_uuid', $domain_uuid)
+            ->delete();
+    }
+
+    private function toTextBool($value): string
+    {
+        if (is_bool($value)) return $value ? 'true' : 'false';
+        if (is_string($value) && in_array(strtolower($value), ['true', 'false'], true)) {
+            return strtolower($value);
+        }
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN) ? 'true' : 'false';
+    }
+}

--- a/app/Http/Requests/Api/V1/StoreUserRequest.php
+++ b/app/Http/Requests/Api/V1/StoreUserRequest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Str;
+
+class StoreUserRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        // API uses route middleware for permissions + domain scope
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'first_name'      => ['required', 'string', 'max:100'],
+            'last_name'       => ['required', 'string', 'max:100'],
+            'user_email'      => ['required', 'email', 'max:255', 'unique:v_users,user_email'],
+            'username'        => ['sometimes', 'nullable', 'string', 'max:255', 'unique:v_users,username'],
+            'password'        => ['required', 'string', 'min:12'],
+            'is_domain_admin' => ['sometimes', 'boolean'],
+            'user_enabled'    => ['sometimes', 'boolean'],
+            'language'        => ['sometimes', 'nullable', 'string', 'max:10'],
+            'time_zone'       => ['sometimes', 'nullable', 'string', 'max:64'],
+        ];
+    }
+
+    public function prepareForValidation(): void
+    {
+        // Derive username from first_name + last_name if not supplied,
+        // matching app/Http/Controllers/UsersController@store behavior.
+        if (! $this->filled('username') && $this->filled('first_name')) {
+            $username = Str::slug((string) $this->input('first_name'), '_');
+            if ($this->filled('last_name')) {
+                $username .= '_' . Str::slug((string) $this->input('last_name'), '_');
+            }
+            $this->merge(['username' => $username]);
+        }
+    }
+
+    public function messages(): array
+    {
+        return [
+            'user_email.unique' => 'A user with this email already exists.',
+            'username.unique'   => 'A user with this username already exists.',
+            'password.min'      => 'The password must be at least 12 characters long.',
+        ];
+    }
+
+    public function bodyParameters(): array
+    {
+        return [
+            'first_name' => [
+                'description' => 'First name of the user.',
+                'example'     => 'Ada',
+            ],
+            'last_name' => [
+                'description' => 'Last name of the user.',
+                'example'     => 'Lovelace',
+            ],
+            'user_email' => [
+                'description' => 'Login email address. Must be globally unique.',
+                'example'     => 'ada.lovelace@example.com',
+            ],
+            'username' => [
+                'description' => 'Optional login username. If omitted it is derived from first_name + last_name.',
+                'example'     => 'ada_lovelace',
+            ],
+            'password' => [
+                'description' => 'Initial password. Minimum 12 characters. Stored hashed via bcrypt.',
+                'example'     => 'correcthorsebatterystaple',
+            ],
+            'is_domain_admin' => [
+                'description' => 'When true, the user is added to the `admin` group for the URL domain — making them a domain administrator. Default: false.',
+                'example'     => true,
+            ],
+            'user_enabled' => [
+                'description' => 'Whether the user can log in. Defaults to true.',
+                'example'     => true,
+            ],
+            'language' => [
+                'description' => 'Preferred UI language code.',
+                'example'     => 'en-us',
+            ],
+            'time_zone' => [
+                'description' => 'IANA time zone name.',
+                'example'     => 'Europe/London',
+            ],
+        ];
+    }
+}

--- a/app/Http/Requests/Api/V1/UpdateUserRequest.php
+++ b/app/Http/Requests/Api/V1/UpdateUserRequest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateUserRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        // API uses route middleware for permissions + domain scope
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $userUuid = (string) $this->route('user_uuid');
+
+        return [
+            'first_name'      => ['sometimes', 'string', 'max:100'],
+            'last_name'       => ['sometimes', 'string', 'max:100'],
+            'user_email'      => [
+                'sometimes',
+                'email',
+                'max:255',
+                Rule::unique('v_users', 'user_email')->ignore($userUuid, 'user_uuid'),
+            ],
+            'username'        => [
+                'sometimes',
+                'string',
+                'max:255',
+                Rule::unique('v_users', 'username')->ignore($userUuid, 'user_uuid'),
+            ],
+            'password'        => ['sometimes', 'string', 'min:12'],
+            'is_domain_admin' => ['sometimes', 'boolean'],
+            'user_enabled'    => ['sometimes', 'boolean'],
+            'language'        => ['sometimes', 'nullable', 'string', 'max:10'],
+            'time_zone'       => ['sometimes', 'nullable', 'string', 'max:64'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'user_email.unique' => 'A user with this email already exists.',
+            'username.unique'   => 'A user with this username already exists.',
+            'password.min'      => 'The password must be at least 12 characters long.',
+        ];
+    }
+
+    public function bodyParameters(): array
+    {
+        return [
+            'first_name'      => ['description' => 'First name of the user.',           'example' => 'Ada'],
+            'last_name'       => ['description' => 'Last name of the user.',            'example' => 'Lovelace'],
+            'user_email'      => ['description' => 'Login email address.',              'example' => 'ada.lovelace@example.com'],
+            'username'        => ['description' => 'Login username.',                   'example' => 'ada_lovelace'],
+            'password'        => ['description' => 'New password (min 12 chars). Hashed before storage.', 'example' => 'correcthorsebatterystaple'],
+            'is_domain_admin' => [
+                'description' => 'When true, ensure user is in the domain `admin` group. When false, remove them from it.',
+                'example'     => false,
+            ],
+            'user_enabled'    => ['description' => 'Whether the user can log in.', 'example' => true],
+            'language'        => ['description' => 'Preferred UI language code.', 'example' => 'en-us'],
+            'time_zone'       => ['description' => 'IANA time zone name.',        'example' => 'Europe/London'],
+        ];
+    }
+}

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Api\V1\RingGroupController;
 use App\Http\Controllers\Api\V1\VoicemailController;
 use App\Http\Controllers\Api\V1\PhoneNumberController;
 use App\Http\Controllers\Api\V1\CdrController;
+use App\Http\Controllers\Api\V1\UserController;
 
 /*
 |--------------------------------------------------------------------------
@@ -149,4 +150,27 @@ Route::middleware(['auth:sanctum', 'api.token.auth', 'throttle:api'])->group(fun
 
     Route::get('/domains/{domain_uuid}/cdrs/{xml_cdr_uuid}', [CdrController::class, 'show'])
         ->middleware('user.authorize:xml_cdr_view');
+
+    /*
+    |--------------------------------------------------------------------------
+    | Users (domain-scoped)
+    |--------------------------------------------------------------------------
+    | Documented CRUD over v_users so external integrations can manage users
+    | without using the internal session-cookie endpoints. is_domain_admin
+    | toggles membership in the global admin group, scoped to the URL domain.
+    */
+    Route::get('/domains/{domain_uuid}/users', [UserController::class, 'index'])
+        ->middleware('user.authorize:user_view');
+
+    Route::get('/domains/{domain_uuid}/users/{user_uuid}', [UserController::class, 'show'])
+        ->middleware('user.authorize:user_view');
+
+    Route::post('/domains/{domain_uuid}/users', [UserController::class, 'store'])
+        ->middleware('user.authorize:user_add');
+
+    Route::patch('/domains/{domain_uuid}/users/{user_uuid}', [UserController::class, 'update'])
+        ->middleware('user.authorize:user_edit');
+
+    Route::delete('/domains/{domain_uuid}/users/{user_uuid}', [UserController::class, 'destroy'])
+        ->middleware('user.authorize:user_delete');
 });

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -11,6 +11,7 @@ use App\Http\Controllers\Api\V1\RingGroupController;
 use App\Http\Controllers\Api\V1\VoicemailController;
 use App\Http\Controllers\Api\V1\PhoneNumberController;
 use App\Http\Controllers\Api\V1\CdrController;
+use App\Http\Controllers\Api\V1\UserController;
 
 /*
 |--------------------------------------------------------------------------
@@ -192,4 +193,27 @@ Route::middleware(['auth:sanctum', 'api.token.auth', 'throttle:api'])->group(fun
 
     Route::get('/domains/{domain_uuid}/cdrs/{xml_cdr_uuid}/recording-url', [CdrController::class, 'recordingUrl'])
         ->middleware('user.authorize:xml_cdr_view');
+
+    /*
+    |--------------------------------------------------------------------------
+    | Users (domain-scoped)
+    |--------------------------------------------------------------------------
+    | Documented CRUD over v_users so external integrations can manage users
+    | without using the internal session-cookie endpoints. is_domain_admin
+    | toggles membership in the global admin group, scoped to the URL domain.
+    */
+    Route::get('/domains/{domain_uuid}/users', [UserController::class, 'index'])
+        ->middleware('user.authorize:user_view');
+
+    Route::get('/domains/{domain_uuid}/users/{user_uuid}', [UserController::class, 'show'])
+        ->middleware('user.authorize:user_view');
+
+    Route::post('/domains/{domain_uuid}/users', [UserController::class, 'store'])
+        ->middleware('user.authorize:user_add');
+
+    Route::patch('/domains/{domain_uuid}/users/{user_uuid}', [UserController::class, 'update'])
+        ->middleware('user.authorize:user_edit');
+
+    Route::delete('/domains/{domain_uuid}/users/{user_uuid}', [UserController::class, 'destroy'])
+        ->middleware('user.authorize:user_delete');
 });


### PR DESCRIPTION
## Summary

Adds documented, Sanctum-authenticated CRUD endpoints under \`/api/v1/domains/{domain_uuid}/users\` so external integrations can manage users (and promote them to domain admins) without using the internal session-cookie endpoints.

### Endpoints

\`\`\`
GET    /api/v1/domains/{domain_uuid}/users               # cursor-paginated list
GET    /api/v1/domains/{domain_uuid}/users/{user_uuid}   # show
POST   /api/v1/domains/{domain_uuid}/users               # create
PATCH  /api/v1/domains/{domain_uuid}/users/{user_uuid}   # update
DELETE /api/v1/domains/{domain_uuid}/users/{user_uuid}   # delete
\`\`\`

### How it works

\`is_domain_admin\` on \`store\` / \`update\` toggles membership in the global admin group, scoped to the URL domain via \`v_user_groups\`. The shape mirrors the existing v1 endpoints (Domain / Extension / Voicemail / Ring Group) — cursor pagination via \`starting_after\`, Scribe documentation annotations, and permission-gated middleware.

Validation is in dedicated FormRequest classes (\`StoreUserRequest\`, \`UpdateUserRequest\`) that map directly to \`v_users\` columns.

## Why community-friendly

- Drops in alongside the existing v1 patterns; no new conventions, no new abstractions.
- Permission-gated by the existing \`user_view\` / \`user_add\` / \`user_edit\` / \`user_delete\` permissions — no new permissions added.
- No external services, no provider-specific code.

## Test plan

- [ ] \`php artisan migrate\` — confirm no schema changes needed.
- [ ] Mint a Sanctum token with \`user_view\` and hit \`GET /api/v1/domains/{uuid}/users\` — confirm cursor-paginated list.
- [ ] \`POST\` a new user with \`is_domain_admin=true\` — confirm v_user_groups row added.
- [ ] \`PATCH\` to set \`is_domain_admin=false\` — confirm v_user_groups row removed for that domain.
- [ ] \`DELETE\` — confirm user removed.
- [ ] Without the relevant permission — confirm 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Updates (June 2026)

Rebased onto current main to resolve conflicts.
