### PR TITLE
Add nullable domain_uuid column to personal_access_tokens

### DIFF
--- a/database/migrations/2026_04_22_172846_add_domain_uuid_to_personal_access_tokens_table.php
+++ b/database/migrations/2026_04_22_172846_add_domain_uuid_to_personal_access_tokens_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('personal_access_tokens', function (Blueprint $table) {
+            $table->uuid('domain_uuid')->nullable()->after('abilities');
+            $table->index('domain_uuid');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('personal_access_tokens', function (Blueprint $table) {
+            $table->dropIndex(['domain_uuid']);
+            $table->dropColumn('domain_uuid');
+        });
+    }
+};


### PR DESCRIPTION
## Summary

Adds an optional \`domain_uuid\` column (with index) to Sanctum's \`personal_access_tokens\` table. The column is nullable and nothing in this migration enforces tenant scoping — it just makes the column available so callers that mint API tokens can optionally attach a domain context.

## Why community-friendly

- Schema only — backwards compatible. Existing tokens (with NULL \`domain_uuid\`) continue to work as global/admin tokens.
- Foundational for tenant-scoped token issuance: a tenant token can carry the domain it was issued for, and consuming middleware can verify the token's domain matches the URL's \`{domain_uuid}\`.
- Follow-up middleware + UI for tenant self-service token management can layer on this without further schema changes.

## Test plan

- [ ] \`php artisan migrate\` — confirm the column appears with index.
- [ ] Mint an existing token via Sanctum — confirm it still works (\`domain_uuid\` is NULL, ignored by all current code paths).
- [ ] \`php artisan migrate:rollback\` — confirm the column and index are dropped cleanly.

## Notes for reviewers

This is a deliberately tiny PR. The follow-up work (a \`ResolveDomainScope\` middleware, a tenant API-token CRUD endpoint, a settings page for users to mint their own tokens) can be reviewed separately on a base that has this column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)