### PR TITLE
Add ring_target column + v1 extension API + bearer-auth lookup

### DIFF
--- a/app/Data/Api/V1/ExtensionData.php
+++ b/app/Data/Api/V1/ExtensionData.php
@@ -58,6 +58,9 @@ class ExtensionData extends Data
         /** Do not disturb enabled */
         public ?bool $do_not_disturb,
 
+        /** Which device(s) ring on inbound calls: "app", "fmc", or "both" */
+        public ?string $ring_target,
+
         /** User record enabled */
         public ?bool $user_record,
 

--- a/app/Http/Controllers/Api/V1/ExtensionController.php
+++ b/app/Http/Controllers/Api/V1/ExtensionController.php
@@ -189,6 +189,7 @@ class ExtensionController extends Controller
                 'directory_visible',
                 'directory_exten_visible',
                 'do_not_disturb',
+                'ring_target',
                 'user_record',
                 'description',
                 'forward_all_enabled',
@@ -238,6 +239,7 @@ class ExtensionController extends Controller
                 email: $e->email,
 
                 do_not_disturb: $toBool($e->do_not_disturb),
+                ring_target: $e->ring_target ?? 'both',
                 user_record: $toBool($e->user_record),
 
                 suspended: $e->suspended !== null ? (bool) $e->suspended : null,
@@ -439,6 +441,7 @@ class ExtensionController extends Controller
                 'directory_visible',
                 'directory_exten_visible',
                 'do_not_disturb',
+                'ring_target',
                 'user_record',
                 'description',
                 'forward_all_enabled',
@@ -490,6 +493,7 @@ class ExtensionController extends Controller
             email: $e->email,
 
             do_not_disturb: $toBool($e->do_not_disturb),
+            ring_target: $e->ring_target ?? 'both',
             user_record: $toBool($e->user_record),
 
             suspended: $e->suspended !== null ? (bool) $e->suspended : null,
@@ -666,6 +670,7 @@ class ExtensionController extends Controller
             // default booleans (DB stores as text)
             'enabled'                 => $boolText($validated['enabled'] ?? null, true),
             'do_not_disturb'          => $boolText($validated['do_not_disturb'] ?? null, false),
+            'ring_target'             => in_array($validated['ring_target'] ?? null, ['app', 'fmc', 'both'], true) ? $validated['ring_target'] : 'both',
             'directory_visible'       => $boolText($validated['directory_visible'] ?? null, true),
             'directory_exten_visible' => $boolText($validated['directory_exten_visible'] ?? null, true),
             'user_record'             => $boolText($validated['user_record'] ?? null, false),
@@ -785,6 +790,7 @@ class ExtensionController extends Controller
                 email: $extension->email ?? null,
 
                 do_not_disturb: filter_var($extension->do_not_disturb, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE),
+                ring_target: $extension->ring_target ?? 'both',
                 user_record: filter_var($extension->user_record, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE),
 
                 suspended: $extension->suspended !== null ? (bool) $extension->suspended : null,
@@ -1021,6 +1027,11 @@ class ExtensionController extends Controller
         }
         if (array_key_exists('sip_force_expires', $inputs)) {
             $update['sip_force_expires'] = $toNumericString($inputs['sip_force_expires']);
+        }
+
+        // ring_target is an enum string column (app/fmc/both)
+        if (array_key_exists('ring_target', $inputs)) {
+            $update['ring_target'] = in_array($inputs['ring_target'], ['app', 'fmc', 'both'], true) ? $inputs['ring_target'] : 'both';
         }
 
         // TEXT boolean columns in v_extensions
@@ -1298,6 +1309,7 @@ class ExtensionController extends Controller
                 email: $fresh->email ?? null,
 
                 do_not_disturb: filter_var($fresh->do_not_disturb, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE),
+                ring_target: $fresh->ring_target ?? 'both',
                 user_record: filter_var($fresh->user_record, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE),
 
                 suspended: (bool) ($fresh->advSettings->suspended ?? false),

--- a/app/Http/Controllers/Api/V1/ExtensionController.php
+++ b/app/Http/Controllers/Api/V1/ExtensionController.php
@@ -189,6 +189,7 @@ class ExtensionController extends Controller
                 'directory_visible',
                 'directory_exten_visible',
                 'do_not_disturb',
+                'ring_target',
                 'user_record',
                 'description',
                 'forward_all_enabled',
@@ -238,6 +239,7 @@ class ExtensionController extends Controller
                 email: $e->email,
 
                 do_not_disturb: $toBool($e->do_not_disturb),
+                ring_target: $e->ring_target ?? 'both',
                 user_record: $toBool($e->user_record),
 
                 suspended: $e->suspended !== null ? (bool) $e->suspended : null,
@@ -439,6 +441,7 @@ class ExtensionController extends Controller
                 'directory_visible',
                 'directory_exten_visible',
                 'do_not_disturb',
+                'ring_target',
                 'user_record',
                 'description',
                 'forward_all_enabled',
@@ -490,6 +493,7 @@ class ExtensionController extends Controller
             email: $e->email,
 
             do_not_disturb: $toBool($e->do_not_disturb),
+            ring_target: $e->ring_target ?? 'both',
             user_record: $toBool($e->user_record),
 
             suspended: $e->suspended !== null ? (bool) $e->suspended : null,
@@ -666,6 +670,7 @@ class ExtensionController extends Controller
             // default booleans (DB stores as text)
             'enabled'                 => $boolText($validated['enabled'] ?? null, true),
             'do_not_disturb'          => $boolText($validated['do_not_disturb'] ?? null, false),
+            'ring_target'             => in_array($validated['ring_target'] ?? null, ['app', 'fmc', 'both'], true) ? $validated['ring_target'] : 'both',
             'directory_visible'       => $boolText($validated['directory_visible'] ?? null, true),
             'directory_exten_visible' => $boolText($validated['directory_exten_visible'] ?? null, true),
             'user_record'             => $boolText($validated['user_record'] ?? null, false),
@@ -790,6 +795,7 @@ class ExtensionController extends Controller
                 email: $extension->email ?? null,
 
                 do_not_disturb: filter_var($extension->do_not_disturb, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE),
+                ring_target: $extension->ring_target ?? 'both',
                 user_record: filter_var($extension->user_record, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE),
 
                 suspended: $extension->suspended !== null ? (bool) $extension->suspended : null,
@@ -1026,6 +1032,11 @@ class ExtensionController extends Controller
         }
         if (array_key_exists('sip_force_expires', $inputs)) {
             $update['sip_force_expires'] = $toNumericString($inputs['sip_force_expires']);
+        }
+
+        // ring_target is an enum string column (app/fmc/both)
+        if (array_key_exists('ring_target', $inputs)) {
+            $update['ring_target'] = in_array($inputs['ring_target'], ['app', 'fmc', 'both'], true) ? $inputs['ring_target'] : 'both';
         }
 
         // TEXT boolean columns in v_extensions
@@ -1309,6 +1320,7 @@ class ExtensionController extends Controller
                 email: $fresh->email ?? null,
 
                 do_not_disturb: filter_var($fresh->do_not_disturb, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE),
+                ring_target: $fresh->ring_target ?? 'both',
                 user_record: filter_var($fresh->user_record, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE),
 
                 suspended: (bool) ($fresh->advSettings->suspended ?? false),

--- a/app/Http/Controllers/ExtensionsController.php
+++ b/app/Http/Controllers/ExtensionsController.php
@@ -2232,4 +2232,35 @@ public function store(StoreExtensionRequest $request)
 
         return $permissions;
     }
+
+    /**
+     * Resolve an extension number + domain name to their fspbx UUIDs.
+     * Used by external machine-to-machine integrations that need to
+     * round-trip extension/domain UUIDs without manual entry.
+     */
+    public function lookupByNumber(Request $request)
+    {
+        $request->validate([
+            'extension' => 'required|string',
+            'domain' => 'required|string',
+        ]);
+
+        $domain = \App\Models\Domain::where('domain_name', $request->input('domain'))->first();
+        if (!$domain) {
+            return response()->json(['success' => false, 'message' => 'Domain not found'], 404);
+        }
+
+        $extension = Extensions::where('domain_uuid', $domain->domain_uuid)
+            ->where('extension', $request->input('extension'))
+            ->first();
+        if (!$extension) {
+            return response()->json(['success' => false, 'message' => 'Extension not found'], 404);
+        }
+
+        return response()->json([
+            'success' => true,
+            'extension_uuid' => $extension->extension_uuid,
+            'domain_uuid' => $domain->domain_uuid,
+        ]);
+    }
 }

--- a/app/Http/Controllers/ExtensionsController.php
+++ b/app/Http/Controllers/ExtensionsController.php
@@ -2368,6 +2368,21 @@ public function store(StoreExtensionRequest $request)
             return response()->json(['success' => false, 'message' => 'Domain not found'], 404);
         }
 
+        // Enforce tenant scope. A personal access token with a non-null
+        // domain_uuid is a tenant token and may only resolve extensions in
+        // its own domain. A null domain_uuid is a global/admin token and may
+        // resolve any domain. This prevents cross-tenant info disclosure
+        // (any valid Sanctum token resolving any extension in any domain).
+        $token = $request->user()?->currentAccessToken();
+        $tokenDomain = $token && $token->domain_uuid ? (string) $token->domain_uuid : null;
+
+        if ($tokenDomain !== null && $tokenDomain !== (string) $domain->domain_uuid) {
+            return response()->json([
+                'success' => false,
+                'message' => 'This token is not permitted to access that domain',
+            ], 403);
+        }
+
         $extension = Extensions::where('domain_uuid', $domain->domain_uuid)
             ->where('extension', $request->input('extension'))
             ->first();

--- a/app/Http/Controllers/ExtensionsController.php
+++ b/app/Http/Controllers/ExtensionsController.php
@@ -2350,4 +2350,35 @@ public function store(StoreExtensionRequest $request)
             ->where('domain_uuid', session('domain_uuid'))
             ->exists();
     }
+
+    /**
+     * Resolve an extension number + domain name to their fspbx UUIDs.
+     * Used by external machine-to-machine integrations that need to
+     * round-trip extension/domain UUIDs without manual entry.
+     */
+    public function lookupByNumber(Request $request)
+    {
+        $request->validate([
+            'extension' => 'required|string',
+            'domain' => 'required|string',
+        ]);
+
+        $domain = \App\Models\Domain::where('domain_name', $request->input('domain'))->first();
+        if (!$domain) {
+            return response()->json(['success' => false, 'message' => 'Domain not found'], 404);
+        }
+
+        $extension = Extensions::where('domain_uuid', $domain->domain_uuid)
+            ->where('extension', $request->input('extension'))
+            ->first();
+        if (!$extension) {
+            return response()->json(['success' => false, 'message' => 'Extension not found'], 404);
+        }
+
+        return response()->json([
+            'success' => true,
+            'extension_uuid' => $extension->extension_uuid,
+            'domain_uuid' => $domain->domain_uuid,
+        ]);
+    }
 }

--- a/app/Http/Requests/Api/V1/StoreExtensionRequest.php
+++ b/app/Http/Requests/Api/V1/StoreExtensionRequest.php
@@ -30,6 +30,7 @@ class StoreExtensionRequest extends FormRequest
             'suspended'   => ['nullable', 'boolean'],
 
             'do_not_disturb' => ['sometimes',  'boolean'],
+            'ring_target'    => ['sometimes', 'string', 'in:app,fmc,both'],
             'enabled'        => ['sometimes', 'boolean'],
             'call_timeout'   => ['sometimes', 'string'],
 
@@ -117,6 +118,10 @@ class StoreExtensionRequest extends FormRequest
             'do_not_disturb' => [
                 'description' => 'Enable Do Not Disturb for this extension. Defaults to false if omitted.',
                 'example' => 'false',
+            ],
+            'ring_target' => [
+                'description' => 'Which device(s) ring on inbound calls: "app", "fmc", or "both". Defaults to "both" if omitted.',
+                'example' => 'both',
             ],
             'enabled' => [
                 'description' => 'Whether the extension is enabled. Defaults to true if omitted.',

--- a/app/Http/Requests/Api/V1/StoreExtensionRequest.php
+++ b/app/Http/Requests/Api/V1/StoreExtensionRequest.php
@@ -31,6 +31,7 @@ class StoreExtensionRequest extends FormRequest
             'suspended'   => ['nullable', 'boolean'],
 
             'do_not_disturb' => ['sometimes',  'boolean'],
+            'ring_target'    => ['sometimes', 'string', 'in:app,fmc,both'],
             'enabled'        => ['sometimes', 'boolean'],
             'call_timeout'   => ['sometimes', 'string'],
 
@@ -126,6 +127,10 @@ class StoreExtensionRequest extends FormRequest
             'do_not_disturb' => [
                 'description' => 'Enable Do Not Disturb for this extension. Defaults to false if omitted.',
                 'example' => 'false',
+            ],
+            'ring_target' => [
+                'description' => 'Which device(s) ring on inbound calls: "app", "fmc", or "both". Defaults to "both" if omitted.',
+                'example' => 'both',
             ],
             'enabled' => [
                 'description' => 'Whether the extension is enabled. Defaults to true if omitted.',

--- a/app/Http/Requests/Api/V1/UpdateExtensionRequest.php
+++ b/app/Http/Requests/Api/V1/UpdateExtensionRequest.php
@@ -32,6 +32,7 @@ class UpdateExtensionRequest extends FormRequest
             'suspended'   => ['sometimes', 'nullable', 'boolean'],
 
             'do_not_disturb' => ['sometimes', 'boolean'],
+            'ring_target'    => ['sometimes', 'string', 'in:app,fmc,both'],
             'enabled'        => ['sometimes', 'boolean'],
             'call_timeout'   => ['sometimes', 'string'],
 
@@ -118,6 +119,10 @@ class UpdateExtensionRequest extends FormRequest
             'do_not_disturb' => [
                 'description' => 'Enable Do Not Disturb for this extension. If omitted, value is unchanged.',
                 'example' => 'false',
+            ],
+            'ring_target' => [
+                'description' => 'Which device(s) ring on inbound calls: "app", "fmc", or "both". Default: "both". If omitted, value is unchanged.',
+                'example' => 'both',
             ],
             'call_timeout' => [
                 'description' => 'Ring timeout in seconds. If omitted, value is unchanged.',

--- a/app/Http/Requests/Api/V1/UpdateExtensionRequest.php
+++ b/app/Http/Requests/Api/V1/UpdateExtensionRequest.php
@@ -33,6 +33,7 @@ class UpdateExtensionRequest extends FormRequest
             'suspended'   => ['sometimes', 'nullable', 'boolean'],
 
             'do_not_disturb' => ['sometimes', 'boolean'],
+            'ring_target'    => ['sometimes', 'string', 'in:app,fmc,both'],
             'enabled'        => ['sometimes', 'boolean'],
             'call_timeout'   => ['sometimes', 'string'],
 
@@ -130,6 +131,10 @@ class UpdateExtensionRequest extends FormRequest
             'do_not_disturb' => [
                 'description' => 'Enable Do Not Disturb for this extension. If omitted, value is unchanged.',
                 'example' => 'false',
+            ],
+            'ring_target' => [
+                'description' => 'Which device(s) ring on inbound calls: "app", "fmc", or "both". Default: "both". If omitted, value is unchanged.',
+                'example' => 'both',
             ],
             'call_timeout' => [
                 'description' => 'Ring timeout in seconds. If omitted, value is unchanged.',

--- a/app/Models/Extensions.php
+++ b/app/Models/Extensions.php
@@ -69,6 +69,7 @@ class Extensions extends Model
         'dial_user',
         'dial_domain',
         'do_not_disturb',
+        'ring_target',
         'forward_all_destination',
         'forward_all_enabled',
         'forward_busy_destination',
@@ -105,6 +106,7 @@ class Extensions extends Model
     protected $attributes = [
         'enabled' => 'true',
         'do_not_disturb' => 'false',
+        'ring_target' => 'both',
         'call_timeout' => '25',
         'call_screen_enabled' => 'false',
         'limit_max' => '5',

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -72,5 +72,14 @@ class RouteServiceProvider extends ServiceProvider
                     return response('', 429);
                 });
         });
+
+        // Machine-to-machine integration endpoints (e.g. the extension lookup)
+        // are an enumeration oracle (404 vs 200). Cap them so a leaked token
+        // can't be used to brute-force the extension/domain space. Keyed by
+        // bearer token, falling back to client IP.
+        RateLimiter::for('integrations', function (Request $request) {
+            $key = $request->bearerToken() ?: $request->ip();
+            return Limit::perMinute(30)->by('integrations:' . $key);
+        });
     }
 }

--- a/database/migrations/2026_04_22_172846_add_domain_uuid_to_personal_access_tokens_table.php
+++ b/database/migrations/2026_04_22_172846_add_domain_uuid_to_personal_access_tokens_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Adds a nullable domain_uuid to personal_access_tokens so a token can be
+ * scoped to a single tenant. A null domain_uuid is a global/admin token.
+ *
+ * This migration is shared with PR #422 (which introduces the same column for
+ * the CDR API). Whichever merges first wins — the migration is idempotent
+ * (hasColumn guard) so running it twice is a no-op.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasColumn('personal_access_tokens', 'domain_uuid')) {
+            return;
+        }
+
+        Schema::table('personal_access_tokens', function (Blueprint $table) {
+            $table->uuid('domain_uuid')->nullable()->after('abilities');
+            $table->index('domain_uuid');
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasColumn('personal_access_tokens', 'domain_uuid')) {
+            return;
+        }
+
+        Schema::table('personal_access_tokens', function (Blueprint $table) {
+            $table->dropIndex(['domain_uuid']);
+            $table->dropColumn('domain_uuid');
+        });
+    }
+};

--- a/database/migrations/2026_04_25_120000_add_ring_target_to_v_extensions_table.php
+++ b/database/migrations/2026_04_25_120000_add_ring_target_to_v_extensions_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('v_extensions', function (Blueprint $table) {
+            $table->string('ring_target')->default('both')->after('do_not_disturb');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('v_extensions', function (Blueprint $table) {
+            $table->dropColumn('ring_target');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -412,3 +412,11 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
     // CHAR PMS
     Route::post('/pms/char', CharPmsWebhookController::class)->name('pms.char');
 });
+
+// Integration endpoints for external services that authenticate with a
+// Sanctum personal access token. The api.token.auth middleware rejects
+// cookie/session requests so these routes are strictly machine-to-machine.
+Route::group(['middleware' => ['auth:sanctum', 'api.token.auth']], function () {
+    Route::get('/integrations/extensions/lookup', [ExtensionsController::class, 'lookupByNumber'])
+        ->name('integrations.extensions.lookup');
+});

--- a/routes/api.php
+++ b/routes/api.php
@@ -708,3 +708,11 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
     // CHAR PMS
     Route::post('/pms/char', CharPmsWebhookController::class)->name('pms.char');
 });
+
+// Integration endpoints for external services that authenticate with a
+// Sanctum personal access token. The api.token.auth middleware rejects
+// cookie/session requests so these routes are strictly machine-to-machine.
+Route::group(['middleware' => ['auth:sanctum', 'api.token.auth']], function () {
+    Route::get('/integrations/extensions/lookup', [ExtensionsController::class, 'lookupByNumber'])
+        ->name('integrations.extensions.lookup');
+});

--- a/routes/api.php
+++ b/routes/api.php
@@ -712,7 +712,10 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
 // Integration endpoints for external services that authenticate with a
 // Sanctum personal access token. The api.token.auth middleware rejects
 // cookie/session requests so these routes are strictly machine-to-machine.
-Route::group(['middleware' => ['auth:sanctum', 'api.token.auth']], function () {
+// The 'integrations' throttle limiter caps these routes so a leaked token
+// can't be used as an enumeration oracle (404 vs 200) against the
+// extension/domain space.
+Route::group(['middleware' => ['auth:sanctum', 'api.token.auth', 'throttle:integrations']], function () {
     Route::get('/integrations/extensions/lookup', [ExtensionsController::class, 'lookupByNumber'])
         ->name('integrations.extensions.lookup');
 });


### PR DESCRIPTION
## Summary

Two related additions for fleet/integration scenarios:

### 1. \`ring_target\` column on \`v_extensions\`

New nullable column (default \`both\`) controls which device class — \`app\`, \`fmc\`, or \`both\` — should ring when an extension has multiple SIP registrations. Surfaced through the existing v1 \`ExtensionController\` GET / POST / PATCH so external integrations can round-trip it. Validation accepts only \`app\` | \`fmc\` | \`both\`.

This is **phase 1**: column + API only. No call-routing changes are made in this PR — the defaults preserve existing behaviour. A follow-up can wire \`ring_target\` into the dialplan / push pipeline.

### 2. Bearer-auth integration lookup endpoint

The existing \`/api/extensions/data\` routes sit behind the \`api.cookie.auth\` middleware, which rejects any request carrying \`Authorization: Bearer\`. That makes them unusable from machine-to-machine integrations that need to resolve an extension number + domain to their fspbx UUIDs.

Adds a new \`Route::group\` using \`auth:sanctum\` + \`api.token.auth\` (bearer required, cookies rejected):

\`\`\`
GET /api/integrations/extensions/lookup?extension=820&domain=example.com
\`\`\`

Returns:
\`\`\`json
{ "success": true, "extension_uuid": "...", "domain_uuid": "..." }
\`\`\`
or 404 if either is unknown.

## Why community-friendly

- \`ring_target\` is a generic FreeSWITCH device-selection feature — anything bridging multiple registrations benefits.
- The lookup endpoint is generic; integrations beyond any specific consumer can use it.
- All additions are additive: no existing behaviour changes.

## Test plan

- [ ] Run \`php artisan migrate\` — verify the \`ring_target\` column is added with default \`both\`.
- [ ] \`POST\` an extension via v1 API with \`ring_target=fmc\`; \`GET\` it back and confirm the value round-trips.
- [ ] \`POST\` with an invalid value (e.g. \`ring_target=xyz\`); confirm 422.
- [ ] Mint a Sanctum personal access token with no scope; \`curl -H 'Authorization: Bearer <token>' /api/integrations/extensions/lookup?extension=820&domain=example.com\`; confirm 200 with UUIDs.
- [ ] Same lookup with cookie auth; confirm rejected.
- [ ] Lookup for unknown extension or unknown domain; confirm 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Updates (June 2026)

- **Lookup endpoint domain scoping:** `ExtensionsController::lookupByNumber` now enforces tenant scope. A personal access token whose `domain_uuid` is non-null is a tenant token and may only resolve extensions within its own domain (returns `403` otherwise); a token with a null `domain_uuid` is a global/admin token and keeps full lookup. This closes the cross-tenant information disclosure where any valid Sanctum token could resolve any extension in any domain.
- **Rate limiting:** the `/api/integrations/*` route group now carries a dedicated `throttle:integrations` limiter (30/min, keyed by bearer token) so a leaked token can't be used as an enumeration oracle (404 vs 200) against the extension/domain space.
- **Migration:** adds the nullable `personal_access_tokens.domain_uuid` column the scoping check reads. This is shared with #422 — whichever merges first wins; the migration is idempotent (`hasColumn` guard), so running it twice is a no-op.
- **Rebased onto current `main`.**
