### PR TITLE
Ring groups: per-member "Skip Voicemail" toggle

### DIFF
--- a/app/Http/Controllers/RingGroupsController.php
+++ b/app/Http/Controllers/RingGroupsController.php
@@ -240,6 +240,7 @@ class RingGroupsController extends Controller
                                 'v_ring_group_destinations.destination_number',
                                 'v_ring_group_destinations.destination_prompt',
                                 'v_ring_group_destinations.destination_timeout',
+                                'v_ring_group_destinations.destination_ignore_voicemail',
                                 DB::raw("CASE 
                             WHEN extension_advanced_settings.suspended = 'true' THEN true
                             ELSE false
@@ -490,6 +491,7 @@ class RingGroupsController extends Controller
                             'destination_timeout'         => isset($member['destination_timeout']) ? (float) $member['destination_timeout'] : 0,
                             'destination_enabled'         => !empty($member['destination_enabled']),
                             'destination_prompt'          => !empty($member['destination_prompt']) ? 1 : null,
+                            'destination_ignore_voicemail' => !empty($member['destination_ignore_voicemail']),
                             'update_date'                 => $now,
                         ];
                     }

--- a/app/Http/Requests/UpdateRingGroupRequest.php
+++ b/app/Http/Requests/UpdateRingGroupRequest.php
@@ -57,6 +57,7 @@ class UpdateRingGroupRequest extends FormRequest
             'members.*.destination_timeout'         => ['required_with:members', 'numeric', 'min:0'],
             'members.*.destination_prompt'          => ['required_with:members', 'boolean'],
             'members.*.destination_enabled'         => ['required_with:members', 'boolean'],
+            'members.*.destination_ignore_voicemail' => ['sometimes', 'boolean'],
 
             // timeout logic: action + optional target
             'timeout_action' => [

--- a/app/Models/RingGroupsDestinations.php
+++ b/app/Models/RingGroupsDestinations.php
@@ -32,6 +32,7 @@ class RingGroupsDestinations extends Model
         'destination_timeout',
         'destination_prompt',
         'destination_enabled',
+        'destination_ignore_voicemail',
         'insert_date',
         'insert_user',
         'update_date',

--- a/database/migrations/2026_04_26_120000_add_destination_ignore_voicemail_to_v_ring_group_destinations.php
+++ b/database/migrations/2026_04_26_120000_add_destination_ignore_voicemail_to_v_ring_group_destinations.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('v_ring_group_destinations', function (Blueprint $table) {
+            $table->boolean('destination_ignore_voicemail')->default(false)->after('destination_enabled');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('v_ring_group_destinations', function (Blueprint $table) {
+            $table->dropColumn('destination_ignore_voicemail');
+        });
+    }
+};

--- a/install/install.sh
+++ b/install/install.sh
@@ -435,6 +435,11 @@ else
 fi
 
 
+print_success "Patching ring_groups lua for Skip Voicemail toggle..."
+bash /var/www/fspbx/install/patch_ring_groups_skip_voicemail.sh || \
+    echo "WARN: ring_groups lua patch failed (non-fatal — re-run manually after FreeSWITCH install)"
+
+
 print_success "Installing FreeSWITCH Sounds..."
 bash /var/www/fspbx/install/install_freeswitch_sounds.sh
 if [ $? -eq 0 ]; then

--- a/install/patch_ring_groups_skip_voicemail.sh
+++ b/install/patch_ring_groups_skip_voicemail.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Patch FusionPBX-shipped ring_groups/index.lua so the per-member
+# `destination_ignore_voicemail` column flows from the database into the
+# per-leg dial-string, suppressing voicemail / no-answer-forward pickup
+# for that member.
+#
+# Idempotent: re-running is a no-op once the patches are in place.
+# Safe to run on every install / upgrade.
+
+set -Eeuo pipefail
+
+LUA="${1:-/usr/share/freeswitch/scripts/app/ring_groups/index.lua}"
+
+print_success() { echo -e "\e[32m$1\e[0m"; }
+print_warn()    { echo -e "\e[33m$1\e[0m"; }
+print_error()   { echo -e "\e[31m$1\e[0m" >&2; }
+
+if [[ ! -f "$LUA" ]]; then
+    print_warn "ring_groups lua not found at $LUA — skipping (FreeSWITCH not installed yet?)"
+    exit 0
+fi
+
+if grep -q "destination_ignore_voicemail" "$LUA"; then
+    print_success "ring_groups lua already patched for Skip Voicemail — skipping"
+    exit 0
+fi
+
+print_success "Patching $LUA for ring-group Skip Voicemail toggle..."
+
+python3 - "$LUA" <<'PY'
+import re, sys, pathlib
+
+path = pathlib.Path(sys.argv[1])
+src = path.read_text()
+
+# 1. Add destination_ignore_voicemail to the SELECT clause that
+#    pulls per-destination columns out of v_ring_group_destinations.
+sql_pattern = re.compile(
+    r"(d\.destination_number, d\.destination_timeout, d\.destination_prompt,)"
+)
+if not sql_pattern.search(src):
+    print("ERROR: could not locate destination SELECT clause in lua", file=sys.stderr)
+    sys.exit(1)
+src = sql_pattern.sub(r"\1 d.destination_ignore_voicemail,", src, count=1)
+
+# 2. Inject voicemail-suppression vars into the per-leg dial-string when
+#    the member has destination_ignore_voicemail set. Anchor on the
+#    `dialed_extension=` concatenation that builds dial_string_user for
+#    the user_exists branch.
+inject_anchor = re.compile(
+    r"(\n([\t ]+)dial_string_user = dial_string_user \.\. \"dialed_extension=\" \.\. row\.destination_number)"
+)
+m = inject_anchor.search(src)
+if not m:
+    print("ERROR: could not locate dial_string_user dialed_extension concat", file=sys.stderr)
+    sys.exit(1)
+
+indent = m.group(2)
+block = (
+    f"\n{indent}-- BEGIN fspbx ring_group_skip_voicemail\n"
+    f"{indent}if (row.destination_ignore_voicemail == \"t\"\n"
+    f"{indent}\t\tor row.destination_ignore_voicemail == true\n"
+    f"{indent}\t\tor row.destination_ignore_voicemail == \"true\"\n"
+    f"{indent}\t\tor row.destination_ignore_voicemail == \"1\"\n"
+    f"{indent}\t\tor row.destination_ignore_voicemail == 1) then\n"
+    f"{indent}\tdial_string_user = dial_string_user\n"
+    f"{indent}\t\t.. \"voicemail_enabled=false,\"\n"
+    f"{indent}\t\t.. \"forward_no_answer_enabled=false,\"\n"
+    f"{indent}\t\t.. \"forward_busy_enabled=false,\"\n"
+    f"{indent}\t\t.. \"bypass_no_answer_forward=true,\"\n"
+    f"{indent}\t\t.. \"hangup_after_bridge=false,\";\n"
+    f"{indent}end\n"
+    f"{indent}-- END fspbx ring_group_skip_voicemail"
+)
+src = inject_anchor.sub(block + r"\1", src, count=1)
+
+path.write_text(src)
+print(f"patched {path}")
+PY
+
+print_success "ring_groups lua patched."
+
+if command -v fs_cli >/dev/null 2>&1; then
+    fs_cli -x "reloadxml" >/dev/null 2>&1 || true
+    print_success "Reloaded FreeSWITCH XML."
+fi

--- a/resources/js/Pages/components/forms/UpdateRingGroupForm.vue
+++ b/resources/js/Pages/components/forms/UpdateRingGroupForm.vue
@@ -269,6 +269,12 @@ Rollover: This option rings each phone one at a time, but it skips busy phones."
                                             info="Enable answer confirmation to prevent voicemails and automated systems from answering a call."
                                             :disabled="() => { return !localOptions.permissions.destination_update }" />
 
+                                        <ToggleElement name="destination_ignore_voicemail"
+                                            :columns="{ default: { container: 6, }, sm: { container: 4, }, }"
+                                            align="left" label="Skip Voicemail" size="sm"
+                                            info="When this member doesn't answer, skip their personal voicemail and continue ringing the next member or fall through to the no-answer action."
+                                            :disabled="() => { return !localOptions.permissions.destination_update }" />
+
                                         <ToggleElement name="destination_enabled"
                                             :columns="{ default: { container: 5 }, sm: { container: 4 } }" size="sm"
                                             label="Active"


### PR DESCRIPTION
## Summary

Adds a per-destination **Skip Voicemail** toggle to ring groups so a caller routed via a ring group can opt out of an individual member's personal voicemail — the call continues ringing the next member (or falls through to the no-answer action) instead of being captured by that extension's voicemail.

The flag is opt-in per member, defaults off, and changes nothing about existing ring-group behaviour when unset.

## Laravel / Vue

- **Migration**: adds `destination_ignore_voicemail` boolean (default `false`) to `v_ring_group_destinations`, positioned after `destination_enabled`.
- **Model**: `RingGroupsDestinations::$fillable` includes the new column.
- **Validation**: `UpdateRingGroupRequest` accepts `members.*.destination_ignore_voicemail` as an optional boolean (`sometimes`) so existing clients keep working.
- **Controller**: `RingGroupsController::update()` persists the new flag; `getItemOptions()` selects it back when loading a ring group for editing.
- **UI**: a `ToggleElement` named **Skip Voicemail** rendered next to the existing **Confirm Answer** toggle on each member row in `UpdateRingGroupForm.vue`.

## FreeSWITCH lua patch (bundled)

`install/patch_ring_groups_skip_voicemail.sh` surgically modifies the FusionPBX-shipped `/usr/share/freeswitch/scripts/app/ring_groups/index.lua` to:

1. `SELECT d.destination_ignore_voicemail` alongside the other destination columns, and
2. inject voicemail-suppression channel vars into that member's per-leg dial-string when the flag is set:
   - `voicemail_enabled=false`
   - `forward_no_answer_enabled=false`
   - `forward_busy_enabled=false`
   - `bypass_no_answer_forward=true`
   - `hangup_after_bridge=false`

The patch is **idempotent** (guards on a marker comment) and is wired into `install/install.sh` to run after `install_freeswitch.sh`, so it applies on every fresh install and is safe to re-run on upgrades. Operators of existing installs can run the script standalone:

```
sudo bash /var/www/fspbx/install/patch_ring_groups_skip_voicemail.sh
```

The script reloads FreeSWITCH XML (`fs_cli -x reloadxml`) when `fs_cli` is available, so the new behaviour takes effect immediately.

## Test plan

- [ ] Run the migration: column appears on `v_ring_group_destinations` with default `false`.
- [ ] Run `install/patch_ring_groups_skip_voicemail.sh`: `index.lua` gains the SQL column + the marked block; re-running prints "already patched — skipping".
- [ ] Edit an existing ring group, toggle **Skip Voicemail** on for one member, save → row's `destination_ignore_voicemail` flips to `true`; reopening the form shows the toggle still on.
- [ ] Toggle off, save → row flips back to `false`.
- [ ] Existing ring groups (members with no `destination_ignore_voicemail` field in payload) still save without errors thanks to the `sometimes` rule.
- [ ] Call a ring group whose member has voicemail enabled and **Skip Voicemail** off → call drops into that member's voicemail as before.
- [ ] Toggle **Skip Voicemail** on for that member, call again → call continues to next member (or falls through to the no-answer action) instead of voicemail.
