### PR TITLE
feat(api/v1): add GET /domains/{d}/cdrs/{c}/recording-url endpoint

### DIFF
--- a/app/Http/Controllers/Api/V1/CdrController.php
+++ b/app/Http/Controllers/Api/V1/CdrController.php
@@ -11,16 +11,21 @@ use Illuminate\Support\Carbon;
 use App\Exceptions\ApiException;
 use App\Http\Controllers\Controller;
 use App\Services\CdrDataService;
+use App\Services\CallRecordingUrlService;
 
 class CdrController extends Controller
 {
     public $item_domain_uuid;
 
     protected CdrDataService $cdrDataService;
+    protected CallRecordingUrlService $callRecordingUrlService;
 
-    public function __construct(CdrDataService $cdrDataService)
-    {
+    public function __construct(
+        CdrDataService $cdrDataService,
+        CallRecordingUrlService $callRecordingUrlService
+    ) {
         $this->cdrDataService = $cdrDataService;
+        $this->callRecordingUrlService = $callRecordingUrlService;
     }
 
     /**
@@ -293,6 +298,98 @@ class CdrController extends Controller
         $payload = $this->cdrDataService->buildApiShowPayload($domain_uuid, $xml_cdr_uuid);
 
         return response()->json($payload->toArray(), 200);
+    }
+
+    /**
+     * Retrieve a temporary recording URL for a Call Detail Record
+     *
+     * Returns time-limited URLs (default 10 minutes) for streaming and
+     * downloading the recording associated with the given CDR. Works
+     * uniformly across both recording-storage backends:
+     *
+     * - **Local storage** (`cdrs.record_path` is a filesystem path):
+     *   Returns Laravel signed routes to the existing `cdrs.recording.stream`
+     *   and `cdrs.recording.download` web endpoints. The signature embeds
+     *   the TTL; no session cookie required by the consumer.
+     * - **S3 / S3-compatible** (`cdrs.record_path === 'S3'`, populated by
+     *   the `fs:upload-call-recordings-to-s3-storage` archival command):
+     *   Returns presigned object URLs minted via the configured per-domain
+     *   S3 disk.
+     *
+     * Either way the consumer can `GET` the URL with no extra auth and
+     * receive the audio bytes (`Content-Disposition: inline` for
+     * `audio_url`, `attachment` for `download_url`).
+     *
+     * Access rules:
+     * - Caller must have access to the target domain (domain scope).
+     * - Caller must have the `xml_cdr_view` permission.
+     *
+     * @group CDRs
+     * @authenticated
+     *
+     * @urlParam domain_uuid string required The domain UUID. Example: 7d58342b-2b29-4dcf-92d6-e9a9e002a4e5
+     * @urlParam xml_cdr_uuid string required The CDR UUID. Example: 40aec3e8-a572-40da-954b-ddf6a8a65324
+     *
+     * @response 200 scenario="Success" {
+     *   "object": "cdr_recording_url",
+     *   "xml_cdr_uuid": "40aec3e8-a572-40da-954b-ddf6a8a65324",
+     *   "audio_url": "https://pbx.example.com/call-detail-records/recordings/40aec3e8-a572-40da-954b-ddf6a8a65324/stream?expires=1775788500&signature=...",
+     *   "download_url": "https://pbx.example.com/call-detail-records/recordings/40aec3e8-a572-40da-954b-ddf6a8a65324/download?expires=1775788500&signature=...",
+     *   "filename": "20260401-120000_2135551212_1001.wav",
+     *   "expires_at": 1775788500
+     * }
+     *
+     * @response 400 scenario="Invalid domain UUID" {"error":{"type":"invalid_request_error","message":"Invalid domain UUID.","code":"invalid_request","param":"domain_uuid"}}
+     * @response 400 scenario="Invalid CDR UUID" {"error":{"type":"invalid_request_error","message":"Invalid CDR UUID.","code":"invalid_request","param":"xml_cdr_uuid"}}
+     * @response 401 scenario="Unauthenticated" {"error":{"type":"authentication_error","message":"Unauthenticated.","code":"unauthenticated"}}
+     * @response 404 scenario="Domain not found" {"error":{"type":"invalid_request_error","message":"Domain not found.","code":"resource_missing","param":"domain_uuid"}}
+     * @response 404 scenario="CDR not found" {"error":{"type":"invalid_request_error","message":"CDR not found.","code":"resource_missing","param":"xml_cdr_uuid"}}
+     * @response 404 scenario="No recording for this CDR" {"error":{"type":"invalid_request_error","message":"No recording available for this CDR.","code":"resource_missing","param":"xml_cdr_uuid"}}
+     */
+    public function recordingUrl(Request $request, string $domain_uuid, string $xml_cdr_uuid)
+    {
+        $user = $request->user();
+
+        if (! $user) {
+            throw new ApiException(401, 'authentication_error', 'Unauthenticated.', 'unauthenticated');
+        }
+
+        if (! preg_match('/^[0-9a-fA-F-]{36}$/', $domain_uuid)) {
+            throw new ApiException(400, 'invalid_request_error', 'Invalid domain UUID.', 'invalid_request', 'domain_uuid');
+        }
+
+        if (! preg_match('/^[0-9a-fA-F-]{36}$/', $xml_cdr_uuid)) {
+            throw new ApiException(400, 'invalid_request_error', 'Invalid CDR UUID.', 'invalid_request', 'xml_cdr_uuid');
+        }
+
+        $domainExists = Domain::query()->where('domain_uuid', $domain_uuid)->exists();
+        if (! $domainExists) {
+            throw new ApiException(404, 'invalid_request_error', 'Domain not found.', 'resource_missing', 'domain_uuid');
+        }
+
+        $cdrExists = CDR::query()
+            ->where('domain_uuid', $domain_uuid)
+            ->where('xml_cdr_uuid', $xml_cdr_uuid)
+            ->exists();
+        if (! $cdrExists) {
+            throw new ApiException(404, 'invalid_request_error', 'CDR not found.', 'resource_missing', 'xml_cdr_uuid');
+        }
+
+        $ttlSeconds = 600;
+        $urls = $this->callRecordingUrlService->urlsForCdr($xml_cdr_uuid, $ttlSeconds);
+
+        if (empty($urls['audio_url'])) {
+            throw new ApiException(404, 'invalid_request_error', 'No recording available for this CDR.', 'resource_missing', 'xml_cdr_uuid');
+        }
+
+        return response()->json([
+            'object' => 'cdr_recording_url',
+            'xml_cdr_uuid' => $xml_cdr_uuid,
+            'audio_url' => $urls['audio_url'],
+            'download_url' => $urls['download_url'],
+            'filename' => $urls['filename'],
+            'expires_at' => Carbon::now()->addSeconds($ttlSeconds)->timestamp,
+        ], 200);
     }
 
     /**

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -149,4 +149,7 @@ Route::middleware(['auth:sanctum', 'api.token.auth', 'throttle:api'])->group(fun
 
     Route::get('/domains/{domain_uuid}/cdrs/{xml_cdr_uuid}', [CdrController::class, 'show'])
         ->middleware('user.authorize:xml_cdr_view');
+
+    Route::get('/domains/{domain_uuid}/cdrs/{xml_cdr_uuid}/recording-url', [CdrController::class, 'recordingUrl'])
+        ->middleware('user.authorize:xml_cdr_view');
 });

--- a/tests/Feature/Api/V1/CdrRecordingUrlTest.php
+++ b/tests/Feature/Api/V1/CdrRecordingUrlTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Tests\Feature\Api\V1;
+
+use App\Services\CallRecordingUrlService;
+use Mockery;
+use Tests\TestCase;
+
+/**
+ * Smoke coverage for `GET /api/v1/domains/{domain_uuid}/cdrs/{xml_cdr_uuid}/recording-url`.
+ *
+ * The repo doesn't ship Feature/Api tests today; this file sets a small
+ * precedent for the new endpoint without forcing a wholesale backfill.
+ * Maintainer is free to drop or restructure it — the controller + route
+ * are independently mergeable.
+ *
+ * Tests cover:
+ *  - 401 when the request is unauthenticated
+ *  - 400 on a malformed UUID (domain or CDR)
+ *  - 200 with the documented payload shape when the underlying
+ *    CallRecordingUrlService returns a populated record
+ *  - 404 when the service returns an empty audio_url (CDR exists but
+ *    has no recording — local file missing or S3 archival hasn't run)
+ *
+ * The 200 + 404 paths mock CallRecordingUrlService directly so the
+ * tests don't need a live DB row, an actual recording on disk, or
+ * configured S3 storage. The earlier guards (401 / 400) are
+ * exercised against the real controller path.
+ */
+class CdrRecordingUrlTest extends TestCase
+{
+    private const DOMAIN_UUID = '7d58342b-2b29-4dcf-92d6-e9a9e002a4e5';
+    private const CDR_UUID = '40aec3e8-a572-40da-954b-ddf6a8a65324';
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_unauthenticated_returns_401(): void
+    {
+        $this->getJson($this->endpoint(self::DOMAIN_UUID, self::CDR_UUID))
+            ->assertStatus(401)
+            ->assertJsonPath('error.type', 'authentication_error')
+            ->assertJsonPath('error.code', 'unauthenticated');
+    }
+
+    public function test_invalid_domain_uuid_returns_400(): void
+    {
+        $this->actingAsApiUserWithCdrView();
+
+        $this->getJson($this->endpoint('not-a-uuid', self::CDR_UUID))
+            ->assertStatus(400)
+            ->assertJsonPath('error.code', 'invalid_request')
+            ->assertJsonPath('error.param', 'domain_uuid');
+    }
+
+    public function test_invalid_cdr_uuid_returns_400(): void
+    {
+        $this->actingAsApiUserWithCdrView();
+
+        $this->getJson($this->endpoint(self::DOMAIN_UUID, 'not-a-uuid'))
+            ->assertStatus(400)
+            ->assertJsonPath('error.code', 'invalid_request')
+            ->assertJsonPath('error.param', 'xml_cdr_uuid');
+    }
+
+    public function test_returns_urls_when_recording_exists(): void
+    {
+        $this->actingAsApiUserWithCdrView();
+        $this->stubDomainAndCdrExist();
+
+        $this->mockRecordingService([
+            'audio_url'    => 'https://pbx.example.com/.../stream?signature=abc',
+            'download_url' => 'https://pbx.example.com/.../download?signature=abc',
+            'filename'     => '20260401-120000_2135551212_1001.wav',
+        ]);
+
+        $response = $this->getJson($this->endpoint(self::DOMAIN_UUID, self::CDR_UUID));
+
+        $response->assertStatus(200)
+            ->assertJsonPath('object', 'cdr_recording_url')
+            ->assertJsonPath('xml_cdr_uuid', self::CDR_UUID)
+            ->assertJsonPath('filename', '20260401-120000_2135551212_1001.wav')
+            ->assertJsonStructure(['object', 'xml_cdr_uuid', 'audio_url', 'download_url', 'filename', 'expires_at']);
+
+        $this->assertGreaterThan(time(), $response->json('expires_at'));
+    }
+
+    public function test_returns_404_when_cdr_has_no_recording(): void
+    {
+        $this->actingAsApiUserWithCdrView();
+        $this->stubDomainAndCdrExist();
+
+        $this->mockRecordingService([
+            'audio_url'    => null,
+            'download_url' => null,
+            'filename'     => null,
+        ]);
+
+        $this->getJson($this->endpoint(self::DOMAIN_UUID, self::CDR_UUID))
+            ->assertStatus(404)
+            ->assertJsonPath('error.code', 'resource_missing')
+            ->assertJsonPath('error.param', 'xml_cdr_uuid');
+    }
+
+    private function endpoint(string $domain, string $cdr): string
+    {
+        return "/api/v1/domains/{$domain}/cdrs/{$cdr}/recording-url";
+    }
+
+    /**
+     * Attaches a Sanctum-authenticated user with the `xml_cdr_view`
+     * permission. Implementation deliberately left for the maintainer
+     * to fill in against the project's existing user/permission
+     * factories — no canonical helper exists in the repo yet.
+     */
+    private function actingAsApiUserWithCdrView(): void
+    {
+        $this->markTestSkipped(
+            'Maintainer to wire `actingAsApiUserWithCdrView` against the project\'s '
+            . 'Sanctum + permission test helpers. The 401 test above runs without auth and '
+            . 'still passes; the 400 / 200 / 404 cases skip pending the helper. '
+            . 'Drop this file entirely if the maintainer prefers to add Feature/Api tests '
+            . 'in a separate pass.'
+        );
+    }
+
+    private function stubDomainAndCdrExist(): void
+    {
+        // Maintainer to stub Domain::query()->where(...)->exists() and
+        // CDR::query()->where(...)->exists() to return true. Easiest
+        // path is a `RefreshDatabase` trait + factory inserts; the
+        // code currently has no factories for Domain / CDR so this
+        // stays as a placeholder.
+    }
+
+    private function mockRecordingService(array $urls): void
+    {
+        $mock = Mockery::mock(CallRecordingUrlService::class);
+        $mock->shouldReceive('urlsForCdr')
+            ->once()
+            ->with(self::CDR_UUID, 600)
+            ->andReturn($urls);
+
+        $this->app->instance(CallRecordingUrlService::class, $mock);
+    }
+}


### PR DESCRIPTION
## Summary

Exposes the existing `CallRecordingUrlService` through the public v1 API so third-party integrations (transcription services, archival tools, analytics pipelines) can fetch the recording for a given CDR without needing the dashboard's session cookie or a Laravel `APP_KEY`-bound signed-route helper.

The endpoint is **purely additive** — it does not change the shape of `GET /domains/{d}/cdrs/{c}` or any other response.

Behavior is identical across both recording-storage backends:

- **Local-disk recordings** → time-limited Laravel signed routes pointing at the existing `cdrs.recording.stream` and `cdrs.recording.download` web endpoints.
- **S3 / S3-compatible recordings** (`cdrs.record_path === 'S3'`, populated by the `fs:upload-call-recordings-to-s3-storage` archival command) → presigned S3 object URLs minted via the configured per-domain disk.

Either way the consumer can `GET` the URL with no extra auth and receive the audio bytes.

## Returned payload

```json
{
  "object": "cdr_recording_url",
  "xml_cdr_uuid": "40aec3e8-a572-40da-954b-ddf6a8a65324",
  "audio_url": "https://pbx.example.com/.../stream?...&signature=...",
  "download_url": "https://pbx.example.com/.../download?...&signature=...",
  "filename": "20260401-120000_2135551212_1001.wav",
  "expires_at": 1775788500
}
```

`expires_at` (epoch seconds = now + TTL) lets clients refetch near expiry without guessing the TTL (default 600s). `404` when the CDR exists but has no recording (local file missing or S3 archival hasn't run yet).

## Auth

Sanctum bearer + `xml_cdr_view` permission, matching the existing CDR show endpoint.

## Files

| File | Change |
|---|---|
| `routes/api_v1.php` | +3 lines — new GET route, same `xml_cdr_view` middleware as the existing CDR endpoints |
| `app/Http/Controllers/Api/V1/CdrController.php` | +101/-2 — inject `CallRecordingUrlService` into the constructor (matches the `CdrDataService` injection style); new `recordingUrl()` method with full Scribe annotations (`@response` for 200/400/401/404 + `@authenticated` + `@urlParam`) so the auto-docs pick it up; reuses the same UUID guards + `Domain` / `CDR` existence checks as `show()` |
| `tests/Feature/Api/V1/CdrRecordingUrlTest.php` | new, +149 lines — 4-test scaffold (401 unauthenticated runs as-is; 400 / 200 / 404 are `markTestSkipped()` pending a project-canonical `actingAsApiUserWithCdrView` helper). Sets a precedent without forcing a wholesale Feature/Api test backfill — happy to drop the file if you'd prefer to land tests in a separate pass |

## What this does NOT do

- No migrations
- No breaking changes
- No new dependencies
- No changes to existing endpoints' response shapes
- No frontend / Vue changes

## Test plan

- `php -l` clean on all three files
- Existing CDR show endpoint (`GET /domains/{d}/cdrs/{c}`) returns identical bytes — diff confirmed against pre-change response
- Manual: against a CDR with an S3-archived recording, `GET /domains/{d}/cdrs/{c}/recording-url` returns a presigned URL that downloads the audio cleanly
- Manual: against a CDR with only a local recording, returns a signed-route URL that streams via `cdrs.recording.stream`
- Manual: against a CDR with no recording, returns 404 with `error.code = "resource_missing"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)