### PR TITLE
Support voicemail download link email delivery

### DIFF
--- a/app/Http/Controllers/Api/V1/ExtensionController.php
+++ b/app/Http/Controllers/Api/V1/ExtensionController.php
@@ -738,6 +738,7 @@ class ExtensionController extends Controller
                         'voicemail_transcription_enabled'  => $boolText($extensionInputs['voicemail_transcription_enabled'] ?? 'true', true),
                         'voicemail_recording_instructions' => $boolText($extensionInputs['voicemail_recording_instructions'] ?? 'true', true),
                         'voicemail_file'                   => $extensionInputs['voicemail_file'] ?? 'attach',
+                        'voicemail_attach_file'            => ($extensionInputs['voicemail_file'] ?? 'attach') === 'attach' ? 'true' : 'false',
                         'voicemail_local_after_email'      => $boolText($extensionInputs['voicemail_local_after_email'] ?? 'true', true),
                         'voicemail_tutorial'               => $boolText($extensionInputs['voicemail_tutorial'] ?? 'true', true),
 
@@ -745,6 +746,10 @@ class ExtensionController extends Controller
                         // greeting_id is numeric in DB. Only include if provided.
                         'greeting_id'                      => $extensionInputs['greeting_id'] ?? null,
                     ];
+
+                    if ($vmInputs['voicemail_file'] === 'link') {
+                        $vmInputs['voicemail_local_after_email'] = 'true';
+                    }
 
                     Voicemails::create($vmInputs);
                 }
@@ -1149,9 +1154,14 @@ class ExtensionController extends Controller
                             }
                             if (array_key_exists('voicemail_file', $inputs)) {
                                 $vmData['voicemail_file'] = $inputs['voicemail_file'];
+                                $vmData['voicemail_attach_file'] = $inputs['voicemail_file'] === 'attach' ? 'true' : 'false';
+
                             }
                             if (array_key_exists('voicemail_local_after_email', $inputs)) {
                                 $vmData['voicemail_local_after_email'] = $boolText($inputs['voicemail_local_after_email']);
+                            }
+                            if (($vmData['voicemail_file'] ?? null) === 'link') {
+                                $vmData['voicemail_local_after_email'] = 'true';
                             }
                             if (array_key_exists('voicemail_transcription_enabled', $inputs)) {
                                 $vmData['voicemail_transcription_enabled'] = $boolText($inputs['voicemail_transcription_enabled']);
@@ -1179,6 +1189,7 @@ class ExtensionController extends Controller
                                 $vmData['voicemail_enabled'] = 'true';
                                 $vmData['voicemail_id'] = $vmData['voicemail_id'] ?? $newExtNumber;
                                 $vmData['voicemail_file'] = $vmData['voicemail_file'] ?? 'attach';
+                                $vmData['voicemail_attach_file'] = $vmData['voicemail_file'] === 'attach' ? 'true' : 'false';
                                 $vmData['voicemail_local_after_email'] = $vmData['voicemail_local_after_email'] ?? 'true';
                                 $vmData['voicemail_transcription_enabled'] = $vmData['voicemail_transcription_enabled'] ?? 'true';
                                 $vmData['voicemail_tutorial'] = $vmData['voicemail_tutorial'] ?? 'true';

--- a/app/Http/Controllers/Api/V1/VoicemailController.php
+++ b/app/Http/Controllers/Api/V1/VoicemailController.php
@@ -525,9 +525,14 @@ class VoicemailController extends Controller
                     'voicemail_recording_instructions' => $boolText($validated['voicemail_recording_instructions'] ?? null, true),
 
                     'voicemail_file'        => $validated['voicemail_file'] ?? 'attach',
+                    'voicemail_attach_file' => ($validated['voicemail_file'] ?? 'attach') === 'attach' ? 'true' : 'false',
                     'voicemail_description' => $validated['voicemail_description'] ?? null,
                     'greeting_id'           => $validated['greeting_id'] ?? null,
                 ];
+
+                if ($inputs['voicemail_file'] === 'link') {
+                    $inputs['voicemail_local_after_email'] = 'true';
+                }
 
                 $vm = Voicemails::create($inputs)->fresh();
 
@@ -736,6 +741,14 @@ class VoicemailController extends Controller
                 ) {
                     if (array_key_exists($key, $inputs)) {
                         $update[$key] = $boolText($inputs[$key]);
+                    }
+                }
+
+                if (array_key_exists('voicemail_file', $update)) {
+                    $update['voicemail_attach_file'] = $update['voicemail_file'] === 'attach' ? 'true' : 'false';
+
+                    if ($update['voicemail_file'] === 'link') {
+                        $update['voicemail_local_after_email'] = 'true';
                     }
                 }
 

--- a/app/Http/Controllers/ExtensionsController.php
+++ b/app/Http/Controllers/ExtensionsController.php
@@ -947,6 +947,15 @@ public function store(StoreExtensionRequest $request)
                 // Prepare necessary linking data
                 $data['extension_uuid'] = $extension->extension_uuid;
                 $data['domain_uuid'] = $extension->domain_uuid;
+                $voicemailData = $data;
+
+                if (array_key_exists('voicemail_file', $voicemailData)) {
+                    $voicemailData['voicemail_attach_file'] = $voicemailData['voicemail_file'] === 'attach' ? 'true' : 'false';
+
+                    if ($voicemailData['voicemail_file'] === 'link') {
+                        $voicemailData['voicemail_local_after_email'] = 'true';
+                    }
+                }
 
                 // Look for an orphaned/existing voicemail box
                 $existingVoicemail = Voicemails::where('domain_uuid', $extension->domain_uuid)
@@ -955,10 +964,10 @@ public function store(StoreExtensionRequest $request)
 
                 if ($existingVoicemail) {
                     // Box exists! Just re-attach it to this extension and update its settings
-                    $existingVoicemail->update($data);
+                    $existingVoicemail->update($voicemailData);
                 } else {
                     // Box doesn't exist, create a brand new one
-                    Voicemails::create($data);
+                    Voicemails::create($voicemailData);
                 }
             }
 
@@ -1228,13 +1237,23 @@ public function store(StoreExtensionRequest $request)
                     ->where('voicemail_id', $extension->extension)
                     ->first();
 
+                $voicemailData = $data;
+
+                if (array_key_exists('voicemail_file', $voicemailData)) {
+                    $voicemailData['voicemail_attach_file'] = $voicemailData['voicemail_file'] === 'attach' ? 'true' : 'false';
+
+                    if ($voicemailData['voicemail_file'] === 'link') {
+                        $voicemailData['voicemail_local_after_email'] = 'true';
+                    }
+                }
+
                 if ($voicemail) {
                     // Re-link and update
-                    $voicemail->update($data);
+                    $voicemail->update($voicemailData);
                 } else {
                     // Create new only if enabled
                     if (($data['voicemail_enabled'] ?? 'false') == 'true') {
-                        Voicemails::create($data);
+                        Voicemails::create($voicemailData);
                     }
                 }
             }
@@ -1617,6 +1636,14 @@ public function store(StoreExtensionRequest $request)
             'extension_uuid' => $extension->extension_uuid,
             'voicemail_id' => $extension->extension,
         ]);
+
+        if (array_key_exists('voicemail_file', $payload)) {
+            $payload['voicemail_attach_file'] = $payload['voicemail_file'] === 'attach' ? 'true' : 'false';
+
+            if ($payload['voicemail_file'] === 'link') {
+                $payload['voicemail_local_after_email'] = 'true';
+            }
+        }
 
         if ($voicemail) {
             $voicemail->update($payload);

--- a/app/Http/Controllers/VoicemailController.php
+++ b/app/Http/Controllers/VoicemailController.php
@@ -138,6 +138,7 @@ class VoicemailController extends Controller
     public function store(StoreVoicemailRequest $request)
     {
         $inputs = $request->validated();
+        $inputs = $this->syncVoicemailAttachFile($inputs);
 
         // If blank, generate
         if (empty($inputs['voicemail_password'])) {
@@ -199,6 +200,7 @@ class VoicemailController extends Controller
     public function update(UpdateVoicemailRequest $request, $uuid)
     {
         $inputs = $request->validated();
+        $inputs = $this->syncVoicemailAttachFile($inputs);
 
         try {
             DB::transaction(function () use ($inputs, $uuid) {
@@ -1386,5 +1388,18 @@ class VoicemailController extends Controller
                 'errors' => ['server' => ['Failed to select all items']]
             ], 500); // 500 Internal Server Error for any other errors
         }
+    }
+
+    private function syncVoicemailAttachFile(array $inputs): array
+    {
+        if (array_key_exists('voicemail_file', $inputs)) {
+            $inputs['voicemail_attach_file'] = $inputs['voicemail_file'] === 'attach' ? 'true' : 'false';
+
+            if ($inputs['voicemail_file'] === 'link') {
+                $inputs['voicemail_local_after_email'] = 'true';
+            }
+        }
+
+        return $inputs;
     }
 }

--- a/app/Http/Controllers/VoicemailMessagesController.php
+++ b/app/Http/Controllers/VoicemailMessagesController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\VoicemailMessages;
 use App\Models\Voicemails;
 use App\Services\FreeswitchEslService;
+use App\Services\VoicemailMessageUrlService;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -212,6 +213,43 @@ class VoicemailMessagesController extends Controller
         $response = Response::download($file, basename($file), $headers);
 
         return $response;
+    }
+
+    public function downloadSignedVoicemailMessage(
+        Request $request,
+        string $message_uuid,
+        VoicemailMessageUrlService $voicemailMessageUrlService
+    ) {
+        if (!$request->hasValidSignature()) {
+            abort(403, 'Invalid or expired link.');
+        }
+
+        $message = VoicemailMessages::findOrFail($message_uuid);
+        $file = $voicemailMessageUrlService->resolveMessageFile($message);
+
+        if (!$file) {
+            abort(404, 'Voicemail recording not found.');
+        }
+
+        $disk = Storage::disk('voicemail');
+
+        if (config('filesystems.disks.voicemail.driver') === 'local') {
+            return response()->download($disk->path($file['path']), $file['filename'], [
+                'Cache-Control' => 'private, max-age=0, no-cache',
+            ]);
+        }
+
+        return response()->streamDownload(function () use ($disk, $file) {
+            $stream = $disk->readStream($file['path']);
+            fpassthru($stream);
+
+            if (is_resource($stream)) {
+                fclose($stream);
+            }
+        }, $file['filename'], [
+            'Content-Type' => $file['mime'],
+            'Cache-Control' => 'private, max-age=0, no-cache',
+        ]);
     }
 
 

--- a/app/Http/Requests/Api/V1/StoreExtensionRequest.php
+++ b/app/Http/Requests/Api/V1/StoreExtensionRequest.php
@@ -5,6 +5,7 @@ namespace App\Http\Requests\Api\V1;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Str;
 use App\Rules\UniqueExtension;
+use Illuminate\Validation\Rule;
 
 class StoreExtensionRequest extends FormRequest
 {
@@ -69,7 +70,7 @@ class StoreExtensionRequest extends FormRequest
 
             'voicemail_id' => ['sometimes'],
 
-            'voicemail_file' => ['nullable'],
+            'voicemail_file' => ['nullable', Rule::in(['attach', 'link', ''])],
 
             'voicemail_local_after_email'        => ['sometimes', 'boolean'],
             'voicemail_transcription_enabled'    => ['sometimes', 'boolean'],
@@ -85,6 +86,14 @@ class StoreExtensionRequest extends FormRequest
     {
         if (!$this->has('suspended')) {
             $this->merge(['suspended' => false]);
+        }
+
+        if ($this->has('voicemail_file')) {
+            $this->merge([
+                'voicemail_file' => in_array($this->input('voicemail_file'), ['attach', 'link'], true)
+                    ? $this->input('voicemail_file')
+                    : '',
+            ]);
         }
     }
 
@@ -254,8 +263,8 @@ class StoreExtensionRequest extends FormRequest
                 'example' => '+12135551212',
             ],
             'voicemail_file' => [
-                'description' => 'Voicemail delivery mode (e.g., attach). Defaults to "attach" if omitted.',
-                'example' => 'attach',
+                'description' => 'Voicemail delivery mode. Use "attach" to attach the recording, "link" to email a signed download link, or blank for notification only. Defaults to "attach" if omitted.',
+                'example' => 'link',
             ],
             'voicemail_local_after_email' => [
                 'description' => 'Whether to keep voicemail local after emailing it. Defaults to true if omitted.',

--- a/app/Http/Requests/Api/V1/StoreVoicemailRequest.php
+++ b/app/Http/Requests/Api/V1/StoreVoicemailRequest.php
@@ -5,6 +5,7 @@ namespace App\Http\Requests\Api\V1;
 use App\Rules\UniqueExtension;
 use App\Rules\ValidVoicemailPassword;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StoreVoicemailRequest extends FormRequest
 {
@@ -34,7 +35,7 @@ class StoreVoicemailRequest extends FormRequest
             'voicemail_enabled' => ['sometimes', 'boolean'],
 
             // Behavior / delivery
-            'voicemail_file' => ['nullable', 'string'],
+            'voicemail_file' => ['nullable', 'string', Rule::in(['attach', 'link', ''])],
             'voicemail_local_after_email'      => ['sometimes', 'boolean'],
             'voicemail_transcription_enabled'  => ['sometimes', 'boolean'],
             'voicemail_tutorial'               => ['sometimes', 'boolean'],
@@ -79,8 +80,8 @@ class StoreVoicemailRequest extends FormRequest
 
             // --- Delivery / behavior ---
             'voicemail_file' => [
-                'description' => 'Voicemail delivery mode (e.g., attach). Defaults to "attach" if omitted.',
-                'example' => 'attach',
+                'description' => 'Voicemail delivery mode. Use "attach" to attach the recording, "link" to email a signed download link, or blank for notification only. Defaults to "attach" if omitted.',
+                'example' => 'link',
             ],
             'voicemail_local_after_email' => [
                 'description' => 'Whether to keep voicemail local after emailing it. Defaults to true if omitted.',

--- a/app/Http/Requests/Api/V1/UpdateExtensionRequest.php
+++ b/app/Http/Requests/Api/V1/UpdateExtensionRequest.php
@@ -4,6 +4,7 @@ namespace App\Http\Requests\Api\V1;
 
 use Illuminate\Foundation\Http\FormRequest;
 use App\Rules\UniqueExtension;
+use Illuminate\Validation\Rule;
 
 class UpdateExtensionRequest extends FormRequest
 {
@@ -74,7 +75,7 @@ class UpdateExtensionRequest extends FormRequest
             'voicemail_enabled' => ['sometimes', 'boolean'],
 
             'voicemail_id' => ['sometimes'],
-            'voicemail_file' => ['sometimes', 'nullable'],
+            'voicemail_file' => ['sometimes', 'nullable', Rule::in(['attach', 'link', ''])],
 
             'voicemail_local_after_email'      => ['sometimes', 'boolean'],
             'voicemail_transcription_enabled'  => ['sometimes', 'boolean'],
@@ -83,6 +84,17 @@ class UpdateExtensionRequest extends FormRequest
             'voicemail_tutorial'               => ['sometimes', 'boolean'],
             'voicemail_recording_instructions' => ['sometimes', 'boolean'],
         ];
+    }
+
+    public function prepareForValidation()
+    {
+        if ($this->has('voicemail_file')) {
+            $this->merge([
+                'voicemail_file' => in_array($this->input('voicemail_file'), ['attach', 'link'], true)
+                    ? $this->input('voicemail_file')
+                    : '',
+            ]);
+        }
     }
 
     public function bodyParameters(): array
@@ -251,8 +263,8 @@ class UpdateExtensionRequest extends FormRequest
                 'example' => '+12135551212',
             ],
             'voicemail_file' => [
-                'description' => 'Voicemail delivery mode (e.g., attach). If omitted, value is unchanged.',
-                'example' => 'attach',
+                'description' => 'Voicemail delivery mode. Use "attach" to attach the recording, "link" to email a signed download link, or blank for notification only. If omitted, value is unchanged.',
+                'example' => 'link',
             ],
             'voicemail_local_after_email' => [
                 'description' => 'Whether to keep voicemail local after emailing it. If omitted, value is unchanged.',

--- a/app/Http/Requests/Api/V1/UpdateVoicemailRequest.php
+++ b/app/Http/Requests/Api/V1/UpdateVoicemailRequest.php
@@ -5,6 +5,7 @@ namespace App\Http\Requests\Api\V1;
 use App\Rules\UniqueExtension;
 use App\Rules\ValidVoicemailPassword;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UpdateVoicemailRequest extends FormRequest
 {
@@ -39,7 +40,7 @@ class UpdateVoicemailRequest extends FormRequest
             'voicemail_recording_instructions' => ['sometimes', 'boolean'],
 
             // Delivery / greeting / label
-            'voicemail_file'               => ['sometimes', 'nullable', 'string', 'max:50'],
+            'voicemail_file'               => ['sometimes', 'nullable', 'string', 'max:50', Rule::in(['attach', 'link', ''])],
             'voicemail_description'        => ['sometimes', 'nullable', 'string', 'max:255'],
             'greeting_id'                  => ['sometimes', 'nullable', 'integer'],
             'voicemail_alternate_greet_id' => ['sometimes', 'nullable', 'integer'],
@@ -98,8 +99,8 @@ class UpdateVoicemailRequest extends FormRequest
             ],
 
             'voicemail_file' => [
-                'description' => 'Voicemail delivery mode (e.g., attach). If omitted, unchanged.',
-                'example' => 'attach',
+                'description' => 'Voicemail delivery mode. Use "attach" to attach the recording, "link" to email a signed download link, or blank for notification only. If omitted, unchanged.',
+                'example' => 'link',
             ],
 
             'voicemail_description' => [

--- a/app/Http/Requests/StoreVoicemailRequest.php
+++ b/app/Http/Requests/StoreVoicemailRequest.php
@@ -6,6 +6,7 @@ use App\Rules\UniqueExtension;
 use App\Rules\ValidVoicemailPassword;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 use libphonenumber\PhoneNumberFormat;
 
 class StoreVoicemailRequest extends FormRequest
@@ -39,7 +40,7 @@ class StoreVoicemailRequest extends FormRequest
             'voicemail_local_after_email' => ['sometimes', 'in:true,false'],
             'voicemail_recording_instructions' => ['sometimes', 'in:true,false'],
 
-            'voicemail_file' => ['sometimes', 'nullable'],
+            'voicemail_file' => ['sometimes', 'nullable', Rule::in(['attach', 'link', ''])],
             'voicemail_alternate_greet_id' => ['nullable', 'numeric'],
             'voicemail_description' => ['nullable', 'string', 'max:100'],
             'voicemail_copies' => ['nullable', 'array'],
@@ -69,7 +70,9 @@ class StoreVoicemailRequest extends FormRequest
 
         if ($this->has('voicemail_file')) {
             $this->merge([
-                'voicemail_file' => $this->input('voicemail_file') === 'attach' ? 'attach' : '',
+                'voicemail_file' => in_array($this->input('voicemail_file'), ['attach', 'link'], true)
+                    ? $this->input('voicemail_file')
+                    : '',
             ]);
         }
 

--- a/app/Http/Requests/UpdateExtensionRequest.php
+++ b/app/Http/Requests/UpdateExtensionRequest.php
@@ -4,6 +4,7 @@ namespace App\Http\Requests;
 
 use App\Rules\UniqueExtension;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UpdateExtensionRequest extends FormRequest
 {
@@ -207,7 +208,7 @@ class UpdateExtensionRequest extends FormRequest
             'voicemail_enabled' => ['sometimes', 'in:true,false,1,0'],
             'voicemail_id' => ['sometimes', 'required'],
             'greeting_id' => ['sometimes', 'required', 'string'],
-            'voicemail_file' => ['nullable'],
+            'voicemail_file' => ['nullable', Rule::in(['attach', 'link', ''])],
             'voicemail_local_after_email' => ['sometimes', 'required', 'in:true,false,1,0'],
             'voicemail_transcription_enabled' => ['sometimes', 'required', 'in:true,false,1,0'],
             'voicemail_description' => ['nullable', 'string'],
@@ -260,6 +261,14 @@ public function prepareForValidation()
         'effective_caller_id_number' => $this->extension,
         'voicemail_mail_to'          => $this->voicemail_mail_to ? strtolower($this->voicemail_mail_to) : null,
     ]);
+
+    if ($this->has('voicemail_file')) {
+        $this->merge([
+            'voicemail_file' => in_array($this->input('voicemail_file'), ['attach', 'link'], true)
+                ? $this->input('voicemail_file')
+                : '',
+        ]);
+    }
 
     // Helper: keep digits, allow a single leading +
     $normalizePhoneLoose = function (?string $v): ?string {

--- a/app/Http/Requests/UpdateVoicemailRequest.php
+++ b/app/Http/Requests/UpdateVoicemailRequest.php
@@ -6,6 +6,7 @@ use App\Rules\UniqueExtension;
 use App\Rules\ValidVoicemailPassword;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 use Illuminate\Validation\Validator;
 use libphonenumber\PhoneNumberFormat;
 
@@ -35,7 +36,7 @@ class UpdateVoicemailRequest extends FormRequest
             'voicemail_local_after_email' => ['sometimes', 'in:true,false'],
             'voicemail_recording_instructions' => ['sometimes', 'in:true,false'],
 
-            'voicemail_file' => ['sometimes', 'nullable'],
+            'voicemail_file' => ['sometimes', 'nullable', Rule::in(['attach', 'link', ''])],
             'voicemail_alternate_greet_id' => ['nullable', 'numeric'],
             'voicemail_description' => ['nullable', 'string', 'max:100'],
             'voicemail_copies' => ['nullable', 'array'],
@@ -94,7 +95,9 @@ class UpdateVoicemailRequest extends FormRequest
         }
 
         if ($this->has('voicemail_file')) {
-            $merge['voicemail_file'] = $this->input('voicemail_file') === 'attach' ? 'attach' : '';
+            $merge['voicemail_file'] = in_array($this->input('voicemail_file'), ['attach', 'link'], true)
+                ? $this->input('voicemail_file')
+                : '';
         }
 
         if ($this->has('voicemail_sms_to') && !blank($this->input('voicemail_sms_to'))) {

--- a/app/Jobs/SendNewVoicemailNotificationByEmail.php
+++ b/app/Jobs/SendNewVoicemailNotificationByEmail.php
@@ -13,6 +13,7 @@ use App\Models\DefaultSettings;
 use App\Models\VoicemailMessages;
 use App\Models\Extensions;
 use App\Mail\VoicemailNotification;
+use App\Services\VoicemailMessageUrlService;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Redis;
@@ -154,6 +155,8 @@ class SendNewVoicemailNotificationByEmail implements ShouldQueue
                 : 'default';
 
             $attachment_path = null; // Initialize attachment path as null
+            $voicemailFileMode = (string) ($message->voicemail?->voicemail_file ?? '');
+            $downloadUrl = null;
 
             // Get voicemail file path
             $base_path =
@@ -203,6 +206,10 @@ class SendNewVoicemailNotificationByEmail implements ShouldQueue
                 }
             }
 
+            if ($voicemailFileMode === 'link' && $attachment_path) {
+                $downloadUrl = app(VoicemailMessageUrlService::class)->downloadUrlForMessage($message);
+            }
+
             $template = EmailTemplate::where(function ($q) use ($domain_uuid) {
                 $q->where('domain_uuid', $domain_uuid)
                     ->orWhereNull('domain_uuid');
@@ -233,6 +240,7 @@ class SendNewVoicemailNotificationByEmail implements ShouldQueue
                 'message_date'       => Carbon::createFromTimestamp($message->created_epoch)->tz($timezone)->toDayDateTimeString(),
                 'message_duration'   => gmdate('i\m s\s', (int) $message->message_length),
                 'message_text'    => (string) $message->message_transcription,
+                'voicemail_download_url' => (string) $downloadUrl,
                 // add more as needed…
             ];
 
@@ -258,12 +266,13 @@ class SendNewVoicemailNotificationByEmail implements ShouldQueue
             }
             $subject = strtr($subjectTpl, $replacements);
             $bodyHtml = strtr($bodyTpl, $replacements);
+            $bodyHtml = $this->applyVoicemailDeliveryInstructions($bodyHtml, $voicemailFileMode, $downloadUrl, $bodyTpl);
 
             $attributes['email_subject'] = $subject;
             $attributes['bodyHtml'] = $bodyHtml;
             $attributes['domain_uuid'] = $domain_uuid;
             $attributes['logId'] = $this->logId;
-            $attributes['attachment_path'] = ($message->voicemail?->voicemail_file ?? null) ? $attachment_path : null;
+            $attributes['attachment_path'] = $voicemailFileMode === 'attach' ? $attachment_path : null;
 
             $uuid    = (string) $message->voicemail_message_uuid;
             $sentKey = "vm:sent:$uuid";
@@ -290,7 +299,7 @@ class SendNewVoicemailNotificationByEmail implements ShouldQueue
             }
 
             // Delete local voicemail if required by voicemail settings
-            if (($message->voicemail?->voicemail_local_after_email ?? 'true') !== 'true') {
+            if ($voicemailFileMode !== 'link' && ($message->voicemail?->voicemail_local_after_email ?? 'true') !== 'true') {
                 $this->deleteVoicemailSilently($message);
             }
 
@@ -365,6 +374,53 @@ class SendNewVoicemailNotificationByEmail implements ShouldQueue
 
         // text, password, select, label, etc.
         return $value;
+    }
+
+    private function applyVoicemailDeliveryInstructions(
+        string $bodyHtml,
+        string $voicemailFileMode,
+        ?string $downloadUrl,
+        string $bodyTpl
+    ): string {
+        $legacyInstructions = '<p>Listen to this voicemail over your phone or by opening the attached sound file. You can also sign in to your account with your credentials to manage and listen to voicemails.</p>';
+
+        if ($voicemailFileMode === 'attach') {
+            return $bodyHtml;
+        }
+
+        $replacement = '<p>Listen to this voicemail over your phone. You can also sign in to your account with your credentials to manage and listen to voicemails.</p>';
+
+        if ($voicemailFileMode === 'link' && $downloadUrl) {
+            $replacement = '<p>Listen to this voicemail over your phone or by using the secure download link below. You can also sign in to your account with your credentials to manage and listen to voicemails.</p>';
+
+            if (strpos($bodyTpl, '${voicemail_download_url}') === false) {
+                $replacement .= $this->voicemailDownloadLinkHtml($downloadUrl);
+            }
+        }
+
+        if (strpos($bodyHtml, $legacyInstructions) !== false) {
+            return str_replace($legacyInstructions, $replacement, $bodyHtml);
+        }
+
+        if ($voicemailFileMode === 'link' && $downloadUrl && strpos($bodyTpl, '${voicemail_download_url}') === false) {
+            return $this->insertBeforeBodyClose($bodyHtml, $this->voicemailDownloadLinkHtml($downloadUrl));
+        }
+
+        return $bodyHtml;
+    }
+
+    private function voicemailDownloadLinkHtml(string $downloadUrl): string
+    {
+        return '<p><a href="' . e($downloadUrl) . '">Download voicemail recording</a></p>';
+    }
+
+    private function insertBeforeBodyClose(string $bodyHtml, string $html): string
+    {
+        if (stripos($bodyHtml, '</body>') !== false) {
+            return preg_replace('/<\/body>/i', $html . '</body>', $bodyHtml, 1);
+        }
+
+        return $bodyHtml . $html;
     }
 
     private function deleteVoicemailSilently(\App\Models\VoicemailMessages $message): void

--- a/app/Services/VoicemailMessageUrlService.php
+++ b/app/Services/VoicemailMessageUrlService.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\VoicemailMessages;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\URL;
+
+class VoicemailMessageUrlService
+{
+    public function downloadUrlForMessage(VoicemailMessages $message, int $ttlSeconds = 604800): ?string
+    {
+        if (!$this->resolveMessageFile($message)) {
+            return null;
+        }
+
+        return URL::temporarySignedRoute(
+            'voicemails.messages.public-download',
+            now()->addSeconds($ttlSeconds),
+            ['message_uuid' => $message->voicemail_message_uuid]
+        );
+    }
+
+    public function resolveMessageFile(VoicemailMessages $message): ?array
+    {
+        $message->loadMissing([
+            'domain:domain_uuid,domain_name',
+            'voicemail:voicemail_uuid,voicemail_id',
+        ]);
+
+        $domainName = $message->domain?->domain_name;
+        $voicemailId = $message->voicemail?->voicemail_id;
+
+        if (!$domainName || !$voicemailId) {
+            return null;
+        }
+
+        $basePath = $domainName . '/' . $voicemailId . '/msg_' . $message->voicemail_message_uuid;
+        $disk = Storage::disk('voicemail');
+
+        foreach (['wav', 'mp3'] as $extension) {
+            $path = $basePath . '.' . $extension;
+
+            if ($disk->exists($path)) {
+                return [
+                    'path' => $path,
+                    'filename' => 'msg_' . $message->voicemail_message_uuid . '.' . $extension,
+                    'mime' => $extension === 'mp3' ? 'audio/mpeg' : 'audio/wav',
+                ];
+            }
+        }
+
+        return null;
+    }
+}

--- a/resources/js/Pages/components/forms/CreateVoicemailForm.vue
+++ b/resources/js/Pages/components/forms/CreateVoicemailForm.vue
@@ -56,8 +56,8 @@
                                     voicemail_enabled: options.item?.voicemail_enabled ?? 'true',
                                     voicemail_description: options.item?.voicemail_description ?? '',
                                     voicemail_transcription_enabled: options.item?.voicemail_transcription_enabled ?? 'true',
-                                    voicemail_file: options.item?.voicemail_file === 'attach' ? 'attach' : '',
-                                    voicemail_local_after_email: options.item?.voicemail_local_after_email ?? 'true',
+                                    voicemail_file: ['attach', 'link'].includes(options.item?.voicemail_file) ? options.item.voicemail_file : '',
+                                    voicemail_local_after_email: options.item?.voicemail_file === 'link' ? 'true' : (options.item?.voicemail_local_after_email ?? 'true'),
                                     voicemail_copies: options.voicemail_copies ?? [],
                                     greeting_id: options.item?.greeting_id ?? '-1',
                                     voicemail_tutorial: options.item?.voicemail_tutorial ?? 'false',
@@ -144,10 +144,11 @@
                                                 <StaticElement name="divider1" tag="hr"
                                                     :conditions="[['voicemail_enabled', '==', 'true']]" />
 
-                                                <ToggleElement name="voicemail_file"
-                                                    text="Attach File to Email Notifications" true-value="attach"
-                                                    false-value=""
-                                                    description="Attach voicemail recording file to the email notification."
+                                                <SelectElement name="voicemail_file" :items="voicemailFileOptions"
+                                                    :native="false" label="Voicemail Email Recording"
+                                                    value-prop="value" label-prop="label"
+                                                    description="Choose how voicemail recordings are included in email notifications."
+                                                    @change="handleVoicemailFileChange"
                                                     :conditions="[['voicemail_enabled', '==', 'true']]" />
 
                                                 <StaticElement name="divider2" tag="hr"
@@ -157,6 +158,7 @@
                                                     text="Automatically Delete Voicemail After Email" true-value="false"
                                                     false-value="true"
                                                     description="Remove voicemail from the cloud once the email is sent."
+                                                    :disabled="isAutoDeleteDisabled"
                                                     :conditions="[['voicemail_enabled', '==', 'true']]" />
 
                                                 <TagsElement name="voicemail_copies" :search="true"
@@ -307,6 +309,23 @@ const props = defineProps({
 });
 
 const form$ = ref(null)
+
+const voicemailFileOptions = [
+    { value: 'attach', label: 'Attach recording' },
+    { value: 'link', label: 'Send download link' },
+    { value: '', label: 'Do not include recording' },
+]
+
+const handleVoicemailFileChange = (newValue, oldValue, el$) => {
+    if (newValue === 'link') {
+        el$.form$.el$('voicemail_local_after_email')?.update('true')
+    }
+}
+
+const isAutoDeleteDisabled = [
+    (el$, form$) => form$.el$('voicemail_file')?.value === 'link',
+]
+
 const isDownloading = ref(false);
 const isNameAudioPlaying = ref(false);
 const isNameDownloading = ref(false);

--- a/resources/js/Pages/components/forms/UpdateExtensionForm.vue
+++ b/resources/js/Pages/components/forms/UpdateExtensionForm.vue
@@ -176,8 +176,8 @@
                                     voicemail_password: options.voicemail?.voicemail_password ?? options.item.voicemail,
                                     voicemail_description: options.voicemail?.voicemail_description ?? '',
                                     voicemail_transcription_enabled: options.voicemail?.voicemail_transcription_enabled ?? 'true',
-                                    voicemail_file: options.voicemail?.voicemail_file === 'attach' ? 'attach' : '',
-                                    voicemail_local_after_email: options.voicemail?.voicemail_local_after_email ?? 'true',
+                                    voicemail_file: ['attach', 'link'].includes(options.voicemail?.voicemail_file) ? options.voicemail.voicemail_file : '',
+                                    voicemail_local_after_email: options.voicemail?.voicemail_file === 'link' ? 'true' : (options.voicemail?.voicemail_local_after_email ?? 'true'),
                                     voicemail_copies: options.voicemail_copies ?? [],
                                     greeting_id: options.voicemail?.greeting_id ?? null,
                                     voicemail_tutorial: options.voicemail?.voicemail_tutorial ?? 'false',
@@ -972,10 +972,11 @@
                                                 <StaticElement name="divider10" tag="hr"
                                                     :conditions="[['voicemail_enabled', '==', 'true']]" />
 
-                                                <ToggleElement name="voicemail_file"
-                                                    text="Attach File to Email Notifications" true-value="attach"
-                                                    false-value=""
-                                                    description="Attach voicemail recording file to the email notification."
+                                                <SelectElement name="voicemail_file" :items="voicemailFileOptions"
+                                                    :native="false" label="Voicemail Email Recording"
+                                                    value-prop="value" label-prop="label"
+                                                    description="Choose how voicemail recordings are included in email notifications."
+                                                    @change="handleVoicemailFileChange"
                                                     :conditions="[['voicemail_enabled', '==', 'true']]" />
 
                                                 <StaticElement name="divider11" tag="hr"
@@ -985,6 +986,7 @@
                                                     text="Automatically Delete Voicemail After Email" true-value="false"
                                                     false-value="true"
                                                     description="Remove voicemail from the cloud once the email is sent."
+                                                    :disabled="isAutoDeleteDisabled"
                                                     :conditions="[['voicemail_enabled', '==', 'true']]" />
 
                                                 <TagsElement name="voicemail_copies" :search="true"
@@ -1899,6 +1901,22 @@ const props = defineProps({
     header: String,
     loading: Boolean,
 });
+
+const voicemailFileOptions = [
+    { value: 'attach', label: 'Attach recording' },
+    { value: 'link', label: 'Send download link' },
+    { value: '', label: 'Do not include recording' },
+]
+
+const handleVoicemailFileChange = (newValue, oldValue, el$) => {
+    if (newValue === 'link') {
+        el$.form$.el$('voicemail_local_after_email')?.update('true')
+    }
+}
+
+const isAutoDeleteDisabled = [
+    (el$, form$) => form$.el$('voicemail_file')?.value === 'link',
+]
 
 const copied = ref({ uuid: false })
 

--- a/resources/js/Pages/components/forms/UpdateVoicemailForm.vue
+++ b/resources/js/Pages/components/forms/UpdateVoicemailForm.vue
@@ -57,8 +57,8 @@
                                     voicemail_enabled: options.item?.voicemail_enabled ?? 'false',
                                     voicemail_description: options.item?.voicemail_description ?? '',
                                     voicemail_transcription_enabled: options.item?.voicemail_transcription_enabled ?? 'true',
-                                    voicemail_file: options.item?.voicemail_file === 'attach' ? 'attach' : '',
-                                    voicemail_local_after_email: options.item?.voicemail_local_after_email ?? 'true',
+                                    voicemail_file: ['attach', 'link'].includes(options.item?.voicemail_file) ? options.item.voicemail_file : '',
+                                    voicemail_local_after_email: options.item?.voicemail_file === 'link' ? 'true' : (options.item?.voicemail_local_after_email ?? 'true'),
                                     voicemail_copies: options.voicemail_copies ?? [],
                                     greeting_id: options.item?.greeting_id ?? null,
                                     voicemail_tutorial: options.item?.voicemail_tutorial ?? 'false',
@@ -214,10 +214,11 @@
                                                 <StaticElement name="divider1" tag="hr"
                                                     :conditions="[['voicemail_enabled', '==', 'true']]" />
 
-                                                <ToggleElement name="voicemail_file"
-                                                    text="Attach File to Email Notifications" true-value="attach"
-                                                    false-value=""
-                                                    description="Attach voicemail recording file to the email notification."
+                                                <SelectElement name="voicemail_file" :items="voicemailFileOptions"
+                                                    :native="false" label="Voicemail Email Recording"
+                                                    value-prop="value" label-prop="label"
+                                                    description="Choose how voicemail recordings are included in email notifications."
+                                                    @change="handleVoicemailFileChange"
                                                     :conditions="[['voicemail_enabled', '==', 'true']]" />
 
                                                 <StaticElement name="divider2" tag="hr"
@@ -227,6 +228,7 @@
                                                     text="Automatically Delete Voicemail After Email" true-value="false"
                                                     false-value="true"
                                                     description="Remove voicemail from the cloud once the email is sent."
+                                                    :disabled="isAutoDeleteDisabled"
                                                     :conditions="[['voicemail_enabled', '==', 'true']]" />
 
                                                 <TagsElement name="voicemail_copies" :search="true"
@@ -795,6 +797,23 @@ const props = defineProps({
 });
 
 const form$ = ref(null)
+
+const voicemailFileOptions = [
+    { value: 'attach', label: 'Attach recording' },
+    { value: 'link', label: 'Send download link' },
+    { value: '', label: 'Do not include recording' },
+]
+
+const handleVoicemailFileChange = (newValue, oldValue, el$) => {
+    if (newValue === 'link') {
+        el$.form$.el$('voicemail_local_after_email')?.update('true')
+    }
+}
+
+const isAutoDeleteDisabled = [
+    (el$, form$) => form$.el$('voicemail_file')?.value === 'link',
+]
+
 const isDownloading = ref(false);
 const isNameAudioPlaying = ref(false);
 const isNameDownloading = ref(false);

--- a/routes/web.php
+++ b/routes/web.php
@@ -116,6 +116,7 @@ Route::match(['GET', 'HEAD'], '/prov/{path}', [ProvisioningController::class, 's
 // Call Recordings
 Route::get('/call-detail-records/recordings/{uuid}/stream', [CallRecordingController::class, 'stream'])->name('cdrs.recording.stream');
 Route::get('/call-detail-records/recordings/{uuid}/download', [CallRecordingController::class, 'download'])->name('cdrs.recording.download');
+Route::get('/voicemails/messages/{message_uuid}/public-download', [VoicemailMessagesController::class, 'downloadSignedVoicemailMessage'])->name('voicemails.messages.public-download');
 
 Route::group(['middleware' => 'auth'], function () {
 


### PR DESCRIPTION
## Summary

Adds support for the legacy `voicemail_file=link` delivery mode so voicemail notification emails can include a signed download link instead of attaching the recording.

## Problem

FusionPBX/FSPBX voicemail rows can store `voicemail_file` as a delivery-mode value. Existing data may use:

- `attach` to attach the voicemail recording to the notification email
- `link` to send a download link instead of an attachment
- blank to notify without including the recording

Today the new voicemail email job treats any non-empty `voicemail_file` value as "attach the recording":

```php
$attributes['attachment_path'] = ($message->voicemail?->voicemail_file ?? null) ? $attachment_path : null;
```

That means `voicemail_file=link` still attaches the audio file. The UI also collapses any value other than `attach` back to blank, so the `link` value cannot be managed from the current forms.

## Changes

- Interpret `voicemail_file` as a delivery mode in `SendNewVoicemailNotificationByEmail`.
  - `attach` attaches the audio file and keeps the existing attached-file wording.
  - `link` does not attach the audio file and adds a signed download link.
  - blank does not include the recording and removes attached-file wording from the default template text.
- Add `VoicemailMessageUrlService` to resolve voicemail audio files and generate temporary signed download URLs.
- Add a signed public download route for voicemail message recordings.
- Add `${voicemail_download_url}` as an email-template variable.
- For existing/default templates that say "opening the attached sound file", replace that sentence with mode-appropriate wording so link/no-recording emails do not mention an attachment.
- Insert a default "Download voicemail recording" link when a mailbox is set to `link` but the active template does not include `${voicemail_download_url}`.
- Update voicemail and extension forms from a boolean attach toggle to a delivery-mode select:
  - Attach recording
  - Send download link
  - Do not include recording
- Disable the auto-delete-after-email toggle when `Send download link` is selected and set it to keep local.
- Preserve `voicemail_file=link` through web and API validation instead of normalizing it away.
- Keep `voicemail_attach_file` synchronized so classic FreeSWITCH voicemail parameters do not keep attaching when the selected delivery mode is `link` or blank.
- Force keep-local behavior on web/API writes when `link` mode is selected so the emailed link does not immediately 404.

## Compatibility

Existing `attach` behavior is preserved. Existing blank behavior remains "no recording included". Existing imported/legacy rows with `voicemail_file=link` start working without a data migration.

## Notes

- The signed link currently defaults to a 7 day lifetime.
- The link route validates Laravel's temporary signature before looking up the voicemail message.
- This does not require email recipients to have a UI login.
