### PR TITLE
Fix device log failures during provisioning

### DIFF
--- a/app/Console/Commands/UpdateApp.php
+++ b/app/Console/Commands/UpdateApp.php
@@ -28,6 +28,7 @@ use App\Console\Commands\Updates\Update168;
 use App\Console\Commands\Updates\Update169;
 use App\Console\Commands\Updates\Update170;
 use App\Console\Commands\Updates\Update171;
+use App\Console\Commands\Updates\Update172;
 use App\Console\Commands\Updates\Update0917;
 use App\Console\Commands\Updates\Update0918;
 use App\Console\Commands\Updates\Update0924;
@@ -132,6 +133,7 @@ class UpdateApp extends Command
             '1.6.9' => Update169::class,
             '1.7.0' => Update170::class,
             '1.7.1' => Update171::class,
+            '1.7.2' => Update172::class,
             // Add more versions as needed
         ];
 

--- a/app/Console/Commands/Updates/Update172.php
+++ b/app/Console/Commands/Updates/Update172.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Console\Commands\Updates;
+
+use Illuminate\Support\Facades\File;
+
+class Update172
+{
+    protected string $deviceLogsPath;
+    protected string $provisionIndexPath;
+
+    public function __construct()
+    {
+        $this->deviceLogsPath = base_path('public/app/device_logs/resources/device_logs.php');
+        $this->provisionIndexPath = base_path('public/app/provision/index.php');
+    }
+
+    /**
+     * Apply update steps.
+     *
+     * @return bool
+     */
+    public function apply()
+    {
+        try {
+            $this->patchDeviceLogsPermissions();
+            $this->guardProvisionDeviceLogInclude();
+
+            return true;
+        } catch (\Throwable $e) {
+            echo "Error patching device log provisioning: " . $e->getMessage() . "\n";
+            return false;
+        }
+    }
+
+    protected function patchDeviceLogsPermissions(): void
+    {
+        if (!File::exists($this->deviceLogsPath)) {
+            echo "Device logs app not installed; skipping permissions patch.\n";
+            return;
+        }
+
+        $contents = File::get($this->deviceLogsPath);
+        $patched = preg_replace('/permissions\s*::\s*new\s*\(\s*\)/', 'new permissions', $contents, -1, $count);
+
+        if ($count === 0) {
+            echo "No legacy device logs permissions instantiation found.\n";
+            return;
+        }
+
+        File::put($this->deviceLogsPath, $patched);
+        echo "Patched device logs permissions instantiation.\n";
+    }
+
+    protected function guardProvisionDeviceLogInclude(): void
+    {
+        if (!File::exists($this->provisionIndexPath)) {
+            echo "Provision index not found; skipping device log include guard.\n";
+            return;
+        }
+
+        $contents = File::get($this->provisionIndexPath);
+
+        if (str_contains($contents, 'Device log write failed during provisioning')) {
+            echo "Provision device log include guard already applied.\n";
+            return;
+        }
+
+        $new = <<<'PHP'
+//device logs
+	if (file_exists($_SERVER["PROJECT_ROOT"]."/app/device_logs/app_config.php")){
+		try {
+			require_once "app/device_logs/resources/device_logs.php";
+		}
+		catch (\Throwable $e) {
+			error_log('Device log write failed during provisioning: '.$e->getMessage());
+		}
+	}
+PHP;
+
+        $pattern = <<<'REGEX'
+#//device logs\s*if\s*\(\s*file_exists\(\s*\$_SERVER\["PROJECT_ROOT"\]\s*\.\s*"/app/device_logs/app_config\.php"\s*\)\s*\)\s*\{\s*require_once\s+"app/device_logs/resources/device_logs\.php"\s*;\s*\}#s
+REGEX;
+
+        $patched = preg_replace_callback($pattern, fn () => $new, $contents, -1, $count);
+
+        if ($count === 0) {
+            echo "Provision device log include block not found; skipping guard.\n";
+            return;
+        }
+
+        File::put($this->provisionIndexPath, $patched);
+        echo "Guarded provision device log include.\n";
+    }
+}

--- a/config/version.php
+++ b/config/version.php
@@ -2,6 +2,6 @@
 
 return [
 
-    'release' => '1.7.0',
+    'release' => '1.7.2',
     
 ];

--- a/install/install_fusionpbx_apps.sh
+++ b/install/install_fusionpbx_apps.sh
@@ -44,6 +44,14 @@ for APP_NAME in "${!APPS[@]}"; do
     # Clone the latest version from the correct GitHub repository
     git clone --depth 1 "$REPO_URL" "$APP_PATH"
 
+    if [[ "$APP_NAME" == "device_logs" ]]; then
+        DEVICE_LOG_FILE="$APP_PATH/resources/device_logs.php"
+        if [[ -f "$DEVICE_LOG_FILE" ]]; then
+            sed -Ei 's/permissions[[:space:]]*::[[:space:]]*new[[:space:]]*\([[:space:]]*\)/new permissions/g' "$DEVICE_LOG_FILE"
+            print_success "Patched device_logs permissions instantiation for FSPBX."
+        fi
+    fi
+
     # Set correct permissions
     chown -R www-data:www-data "$APP_PATH"
     print_success "$APP_NAME installed successfully."


### PR DESCRIPTION
## Summary

This pr fixes a production provisioning failure caused by the legacy `device_logs` app calling `permissions::new()` while provisioning responses are being served.

Observed failure on FSPBX/PHP 8.4:

```text
PHP Fatal error: Uncaught Error: Call to undefined method permissions::new()
/var/www/fspbx/public/app/device_logs/resources/device_logs.php:55
#0 /var/www/fspbx/public/app/provision/index.php(530): require_once()
```

That error occurs after `/app/provision/<mac>.cfg` requests reach the legacy provision endpoint. Device logging should not be able to break provisioning responses.

## Changes

- Adds `Update172` for version `1.7.2`.
- Patches installed `public/app/device_logs/resources/device_logs.php` from legacy `permissions::new()` calls to `new permissions` using whitespace-tolerant matching.
- Wraps the legacy provision endpoint's device-log include in a `try/catch` so logging failures are written to PHP error logs but do not interrupt provisioning responses.
- Applies the same `device_logs` permissions patch during `install/install_fusionpbx_apps.sh` for fresh installs.

## Validation

- `php -l app/Console/Commands/Updates/Update172.php` passed.
- `php -l app/Console/Commands/UpdateApp.php` passed.
- `bash -n install/install_fusionpbx_apps.sh` passed.
- `git diff --check` passed.
- Regex patch patterns were validated against copies of the production `provision/index.php` and `device_logs.php` files.

```text
public/resources/classes/cache.php: No such file or directory
```

## Notes

The root bug is in the upstream FusionPBX `fusionpbx-app-device_logs` app, but FSPBX installs that app directly during setup. This patch protects FSPBX installs and upgrades from the known fatal while keeping the change narrow.