### PR TITLE
Mobile app bug fixes

### DIFF
--- a/app/Http/Controllers/AppsController.php
+++ b/app/Http/Controllers/AppsController.php
@@ -584,6 +584,10 @@ class AppsController extends Controller
             $deleteResponse = $this->ringotelApiService->deleteOrganization($org_id);
 
             if ($deleteResponse) {
+                MobileAppUsers::where('domain_uuid', $domain_uuid)
+                    ->where('org_id', $org_id)
+                    ->delete();
+
                 return response()->json([
                     'messages' => ['success' => ['Organization and its connections were successfully deleted.']]
                 ], 200); // 200 OK

--- a/resources/js/Pages/components/forms/CreateRingotelOrgForm.vue
+++ b/resources/js/Pages/components/forms/CreateRingotelOrgForm.vue
@@ -252,12 +252,16 @@ watch(
 
 const page = usePage();
 
+const isEnabledSetting = (value) => {
+    return value === true || value === 'true' || value === 't' || value === 1 || value === '1';
+};
+
 const form = reactive({
     organization_name: props.options.model.domain_description,
     organization_domain: props.options.settings.suggested_ringotel_domain,
     region: props.options.settings.organization_region,
     package: props.options.settings.package,
-    dont_send_user_credentials: props.options.settings.dont_send_user_credentials === "true",
+    dont_send_user_credentials: isEnabledSetting(props.options.settings.dont_send_user_credentials),
     domain_uuid: props.options.model.domain_uuid,
     _token: page.props.csrf_token,
 })


### PR DESCRIPTION
Bug 1 - dont_send_user_credentials was not being pulled from default settings when creating new mobile app organization

Bug 2 - #56 - when erasing an organization, the extension UUID data associated with it was not being deleted. As a result, if mobile apps were to be added to that same organization at a later time, "no organization found" would appear when trying to enable mobile apps for extensions that previously had it connected