### PR TITLE
Minor bug fix with domain switcher

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -121,7 +121,7 @@ if (!function_exists('getFusionPBXPreviousURL')) {
         } elseif (strpos($previous_url, "/voicemails/")) {
             $url = substr($previous_url, 0, strpos(url()->previous(), "/voicemails/")) . "/voicemails";
         } elseif (strpos($previous_url, "/contact-center/")) {
-            $url = substr($previous_url, 0, strpos(url()->previous(), "/contact-center/")) . "/dashboard1";
+            $url = substr($previous_url, 0, strpos(url()->previous(), "/contact-center/")) . "/dashboard";
         } else {
             $url = $previous_url;
         }


### PR DESCRIPTION
In the domain switcher within the Contact Center page, if a new domain is selected, the user is redirected to /dashboard1 resulting in a 404 not found