### PR TITLE
Logs Page - Multiple fixes

### DIFF
--- a/app/Http/Controllers/AppsController.php
+++ b/app/Http/Controllers/AppsController.php
@@ -1008,7 +1008,7 @@ class AppsController extends Controller
                     $user['password_url'] = $includePasswordUrl;
                 }
                 if ($extension->email) {
-                    SendAppCredentials::dispatch($user)->onQueue('emails');
+                    $this->dispatchAppCredentials($user, $extension->domain_uuid);
                 }
             }
 
@@ -1155,7 +1155,7 @@ class AppsController extends Controller
                     $user['password_url'] = $includePasswordUrl;
                 }
                 if ($email) {
-                    SendAppCredentials::dispatch($user)->onQueue('emails');
+                    $this->dispatchAppCredentials($user, $extension->domain_uuid);
                 }
             }
 
@@ -1351,7 +1351,7 @@ class AppsController extends Controller
                             $user['password_url'] = route('appsGetPasswordByToken', $passwordToken);
                         }
 
-                        SendAppCredentials::dispatch($user)->onQueue('emails');
+                        $this->dispatchAppCredentials($user, $extension->domain_uuid);
                     }
 
                     $processed++;
@@ -1424,7 +1424,7 @@ class AppsController extends Controller
                             $user['password_url'] = route('appsGetPasswordByToken', $passwordToken);
                         }
 
-                        SendAppCredentials::dispatch($user)->onQueue('emails');
+                        $this->dispatchAppCredentials($user, $extension->domain_uuid);
                     }
 
                     $processed++;
@@ -1535,7 +1535,7 @@ class AppsController extends Controller
                     $user['password_url'] = $includePasswordUrl;
                 }
                 if ($extension->email) {
-                    SendAppCredentials::dispatch($user)->onQueue('emails');
+                    $this->dispatchAppCredentials($user, $extension->domain_uuid);
                 }
             }
 
@@ -1705,5 +1705,12 @@ class AppsController extends Controller
         });
 
         return $regions;
+    }
+
+    protected function dispatchAppCredentials(array $user, ?string $domainUuid): void
+    {
+        $user['domain_uuid'] = $domainUuid;
+
+        SendAppCredentials::dispatch($user)->onQueue('emails');
     }
 }

--- a/app/Http/Controllers/TestEmailController.php
+++ b/app/Http/Controllers/TestEmailController.php
@@ -39,12 +39,15 @@ class TestEmailController extends Controller
         } catch (\Throwable $exception) {
             if (isset($logId)) {
                 try {
-                    EmailLog::query()
-                        ->where('uuid', $logId)
-                        ->update([
-                            'status' => 'failed',
-                            'sent_debug_info' => 'Test email failed at ' . now()->toDateTimeString() . ': ' . $exception->getMessage(),
+                    $log = EmailLog::query()->find($logId);
+
+                    if ($log) {
+                        logger('TestEmailController@store transport reported an error after logging test email: ' . $exception->getMessage());
+
+                        return response()->json([
+                            'messages' => ['success' => ['Test email submitted. Check the email logs for delivery status.']],
                         ]);
+                    }
                 } catch (\Throwable $logException) {
                     logger('TestEmailController@store log update error: ' . $logException->getMessage());
                 }

--- a/resources/js/Pages/Logs.vue
+++ b/resources/js/Pages/Logs.vue
@@ -152,6 +152,7 @@ const messageLogsTrigger = ref(false)
 const faxLogsTrigger = ref(false)
 const freeswitchLogsTrigger = ref(false)
 const initialMenuOption = ref(null)
+const selectedMenuOption = ref(null)
 const showTestEmailModal = ref(false)
 const testEmailLoading = ref(false)
 const testEmailErrors = ref({})
@@ -166,11 +167,18 @@ const pages = [
 ]
 
 const handleUpdateSelectedMenuOption = (key) => {
+    selectedMenuOption.value = key
     if (key === 'emails') emailsTrigger.value = !emailsTrigger.value
     if (key === 'inbound_webhooks') inboundWebhooksTrigger.value = !inboundWebhooksTrigger.value
     if (key === 'message_logs') messageLogsTrigger.value = !messageLogsTrigger.value
     if (key === 'fax_logs') faxLogsTrigger.value = !faxLogsTrigger.value
     if (key === 'freeswitch_logs') freeswitchLogsTrigger.value = !freeswitchLogsTrigger.value
+}
+
+const refreshEmailLogsIfVisible = () => {
+    if (selectedMenuOption.value === 'emails') {
+        emailsTrigger.value = !emailsTrigger.value
+    }
 }
 
 const navigation = computed(() => {
@@ -241,7 +249,7 @@ const sendTestEmail = () => {
         notificationType.value = 'success'
         notificationMessages.value = response.data.messages
         notificationShow.value = true
-        emailsTrigger.value = !emailsTrigger.value
+        refreshEmailLogsIfVisible()
     }).catch((error) => {
         testEmailErrors.value = error.response?.data?.errors ?? {}
         notificationType.value = 'error'
@@ -249,6 +257,7 @@ const sendTestEmail = () => {
             ?? error.response?.data?.errors
             ?? { error: ['Unable to send the test email.'] }
         notificationShow.value = true
+        refreshEmailLogsIfVisible()
     }).finally(() => {
         testEmailLoading.value = false
     })

--- a/resources/js/Pages/components/EmailLogs.vue
+++ b/resources/js/Pages/components/EmailLogs.vue
@@ -267,7 +267,7 @@
 </template>
 
 <script setup>
-import { ref, computed, watch } from 'vue';
+import { ref, computed, onMounted, watch } from 'vue';
 import Notification from "./notifications/Notification.vue";
 import ConfirmationModal from "./modal/ConfirmationModal.vue";
 import AddEditItemModal from "./modal/AddEditItemModal.vue";
@@ -388,6 +388,10 @@ const fetchData = async (page = 1) => {
 
 
 watch(() => props.trigger, (newVal) => {
+    fetchData(1)
+})
+
+onMounted(() => {
     fetchData(1)
 })
 


### PR DESCRIPTION
- Test email send would falsely claim that the test email was unsuccessful
- Mobile app emails were not getting filtered properly to the domain name. Mobile app credential emails now include the extension’s domain_uuid, so they appear under the current domain filter instead of only under All Domains.
- Emails should load up when the page loads rather than having to manually click the search button
- Test email sends refresh the Email logs tab when that tab is active, so the log state updates.