### PR TITLE
Set a flag on Voicemail Call Return

### DIFF
--- a/resources/freeswitch_scripts/app/voicemail/resources/functions/return_call.lua
+++ b/resources/freeswitch_scripts/app/voicemail/resources/functions/return_call.lua
@@ -30,6 +30,12 @@
 				dtmf_digits = '';
 			--flush dtmf digits from the input buffer
 				session:flushDigits();
+            --mark this call as a voicemail return-call before transferring back to XML
+                                session:setVariable("vm_return_call", "true");
+                                session:setVariable("vm_return_destination", destination or "");
+            --export so the variable follows the outbound bridge/B-leg too
+                                session:execute("export", "vm_return_call=true");
+                                session:execute("export", "vm_return_destination=" .. (destination or ""));
 			--transfer the call
 				session:transfer(destination, "XML", context);
 		end


### PR DESCRIPTION
Set a flag on voicemail call return so that superadmins can set a condition to block international calls, if necessary. This is to maintain control over a security vulnerability where someone can dial to a voicemail with an international caller ID and then later login to the voicemail (insecure password, etc) and initiate the callback function.