### PR TITLE
Logs page updates and fixes

### DIFF
--- a/app/Http/Controllers/AppsController.php
+++ b/app/Http/Controllers/AppsController.php
@@ -1008,7 +1008,7 @@ class AppsController extends Controller
                     $user['password_url'] = $includePasswordUrl;
                 }
                 if ($extension->email) {
-                    SendAppCredentials::dispatch($user)->onQueue('emails');
+                    $this->dispatchAppCredentials($user, $extension->domain_uuid);
                 }
             }
 
@@ -1155,7 +1155,7 @@ class AppsController extends Controller
                     $user['password_url'] = $includePasswordUrl;
                 }
                 if ($email) {
-                    SendAppCredentials::dispatch($user)->onQueue('emails');
+                    $this->dispatchAppCredentials($user, $extension->domain_uuid);
                 }
             }
 
@@ -1351,7 +1351,7 @@ class AppsController extends Controller
                             $user['password_url'] = route('appsGetPasswordByToken', $passwordToken);
                         }
 
-                        SendAppCredentials::dispatch($user)->onQueue('emails');
+                        $this->dispatchAppCredentials($user, $extension->domain_uuid);
                     }
 
                     $processed++;
@@ -1424,7 +1424,7 @@ class AppsController extends Controller
                             $user['password_url'] = route('appsGetPasswordByToken', $passwordToken);
                         }
 
-                        SendAppCredentials::dispatch($user)->onQueue('emails');
+                        $this->dispatchAppCredentials($user, $extension->domain_uuid);
                     }
 
                     $processed++;
@@ -1535,7 +1535,7 @@ class AppsController extends Controller
                     $user['password_url'] = $includePasswordUrl;
                 }
                 if ($extension->email) {
-                    SendAppCredentials::dispatch($user)->onQueue('emails');
+                    $this->dispatchAppCredentials($user, $extension->domain_uuid);
                 }
             }
 
@@ -1705,5 +1705,12 @@ class AppsController extends Controller
         });
 
         return $regions;
+    }
+
+    protected function dispatchAppCredentials(array $user, ?string $domainUuid): void
+    {
+        $user['domain_uuid'] = $domainUuid;
+
+        SendAppCredentials::dispatch($user)->onQueue('emails');
     }
 }

--- a/app/Http/Controllers/TestEmailController.php
+++ b/app/Http/Controllers/TestEmailController.php
@@ -35,16 +35,21 @@ class TestEmailController extends Controller
 
             return response()->json([
                 'messages' => ['success' => ['Test email sent.']],
+                'log_uuid' => $logId,
             ]);
         } catch (\Throwable $exception) {
             if (isset($logId)) {
                 try {
-                    EmailLog::query()
-                        ->where('uuid', $logId)
-                        ->update([
-                            'status' => 'failed',
-                            'sent_debug_info' => 'Test email failed at ' . now()->toDateTimeString() . ': ' . $exception->getMessage(),
+                    $log = EmailLog::query()->find($logId);
+
+                    if ($log) {
+                        logger('TestEmailController@store transport reported an error after logging test email: ' . $exception->getMessage());
+
+                        return response()->json([
+                            'messages' => ['success' => ['Test email submitted. Check the email logs for delivery status.']],
+                            'log_uuid' => $logId,
                         ]);
+                    }
                 } catch (\Throwable $logException) {
                     logger('TestEmailController@store log update error: ' . $logException->getMessage());
                 }

--- a/app/Http/Webhooks/Jobs/ProcessPostmarkWebhookJob.php
+++ b/app/Http/Webhooks/Jobs/ProcessPostmarkWebhookJob.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Webhooks\Jobs;
 
+use App\Models\EmailLog;
 use App\Services\FaxSendService;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Redis;
 use Spatie\WebhookClient\Models\WebhookCall;
 use Spatie\WebhookClient\Jobs\ProcessWebhookJob as SpatieProcessWebhookJob;
@@ -18,12 +20,18 @@ class ProcessPostmarkWebhookJob extends SpatieProcessWebhookJob
 
     public function __construct(WebhookCall $webhookCall)
     {
-        $this->queue = 'faxes';
+        $this->queue = $this->isOutboundEmailEvent($webhookCall->payload ?? []) ? 'emails' : 'faxes';
         $this->webhookCall = $webhookCall;
     }
 
     public function handle()
     {
+        if ($this->isOutboundEmailEvent($this->webhookCall->payload ?? [])) {
+            $this->processOutboundEmailEvent($this->webhookCall->payload ?? []);
+
+            return;
+        }
+
         // Allow at most 2 fax dispatches per second across the cluster.
         Redis::throttle('fax')->allow(2)->every(1)->then(function () {
             $payload = $this->webhookCall->payload;
@@ -59,5 +67,117 @@ class ProcessPostmarkWebhookJob extends SpatieProcessWebhookJob
 
             return $this->release(5);
         });
+    }
+
+    private function processOutboundEmailEvent(array $payload): void
+    {
+        $messageId = (string) ($payload['MessageID'] ?? '');
+        $metadataLogId = (string) data_get($payload, 'Metadata.email_log_uuid', '');
+        $recipient = (string) ($payload['Recipient'] ?? $payload['Email'] ?? '');
+
+        $log = EmailLog::query()
+            ->where(function ($query) use ($metadataLogId, $messageId, $recipient) {
+                if ($metadataLogId !== '') {
+                    $query->where('uuid', $metadataLogId);
+                }
+
+                if ($messageId !== '') {
+                    $method = $metadataLogId !== '' ? 'orWhere' : 'where';
+                    $query->{$method}('provider_message_id', $messageId);
+                }
+
+                if ($recipient !== '') {
+                    $method = $metadataLogId !== '' || $messageId !== '' ? 'orWhere' : 'where';
+                    $query->{$method}(function ($query) use ($recipient) {
+                        $query->where('to', 'ILIKE', '%' . $recipient . '%')
+                            ->where('provider', 'postmark')
+                            ->where('created_at', '>=', Carbon::now()->subDays(2));
+                    });
+                }
+            })
+            ->latest('created_at')
+            ->first();
+
+        if (! $log) {
+            logger('ProcessPostmarkWebhookJob: email log not found for outbound event', [
+                'webhook_call_id' => $this->webhookCall->id ?? null,
+                'message_id' => $messageId,
+                'metadata_email_log_uuid' => $metadataLogId ?: null,
+                'recipient' => $recipient ?: null,
+                'record_type' => $payload['RecordType'] ?? null,
+                'type' => $payload['Type'] ?? null,
+            ]);
+
+            return;
+        }
+
+        $updates = [
+            'provider' => 'postmark',
+            'provider_message_id' => $messageId ?: $log->provider_message_id,
+            'provider_message_stream' => $payload['MessageStream'] ?? $log->provider_message_stream,
+            'sent_debug_info' => $this->eventSummary($payload),
+        ];
+
+        $status = $this->statusForOutboundEvent($payload);
+
+        if ($status !== null) {
+            $updates['status'] = $status;
+        }
+
+        if ($status === 'sent' && in_array($log->status, ['failed', 'permanent_failed'], true)) {
+            unset($updates['status']);
+        }
+
+        $log->forceFill($updates)->save();
+    }
+
+    private function statusForOutboundEvent(array $payload): ?string
+    {
+        $recordType = $payload['RecordType'] ?? null;
+
+        if ($recordType === 'Delivery') {
+            return 'sent';
+        }
+
+        if ($recordType === 'Transient') {
+            return 'failed';
+        }
+
+        if ($recordType === 'SpamComplaint') {
+            return 'permanent_failed';
+        }
+
+        if ($recordType === 'Bounce') {
+            $bounceType = strtolower((string) ($payload['Type'] ?? ''));
+
+            return in_array($bounceType, ['softbounce', 'transient', 'smtpapierror', 'undetermined'], true)
+                ? 'failed'
+                : 'permanent_failed';
+        }
+
+        return null;
+    }
+
+    private function eventSummary(array $payload): string
+    {
+        $parts = array_filter([
+            'Postmark ' . ($payload['RecordType'] ?? 'event'),
+            $payload['Type'] ?? null,
+            $payload['Name'] ?? null,
+            $payload['Description'] ?? null,
+            $payload['Details'] ?? null,
+        ]);
+
+        return implode(': ', $parts);
+    }
+
+    private function isOutboundEmailEvent(array $payload): bool
+    {
+        return in_array($payload['RecordType'] ?? null, [
+            'Delivery',
+            'Transient',
+            'Bounce',
+            'SpamComplaint',
+        ], true) && !empty($payload['MessageID']);
     }
 }

--- a/app/Http/Webhooks/WebhookProfiles/PostmarkWebhookProfile.php
+++ b/app/Http/Webhooks/WebhookProfiles/PostmarkWebhookProfile.php
@@ -9,6 +9,10 @@ class PostmarkWebhookProfile extends FaxWebhookProfile
 {
     public function shouldProcess(Request $request): bool
     {
+        if ($this->isOutboundEmailEvent($request)) {
+            return true;
+        }
+
         // 1. Extract raw destination
         $toEmail = $request['ToFull'][0]['Email'] ?? null;
         if (!$toEmail || strpos($toEmail, '@') === false) {
@@ -96,5 +100,15 @@ class PostmarkWebhookProfile extends FaxWebhookProfile
             }
         }
         return $stored;
+    }
+
+    private function isOutboundEmailEvent(Request $request): bool
+    {
+        return in_array($request['RecordType'] ?? null, [
+            'Delivery',
+            'Transient',
+            'Bounce',
+            'SpamComplaint',
+        ], true) && !empty($request['MessageID']);
     }
 }

--- a/app/Services/EmailProviderDetailsService.php
+++ b/app/Services/EmailProviderDetailsService.php
@@ -87,13 +87,14 @@ class EmailProviderDetailsService
         }
 
         $payload = $response->json();
+        $logStatus = $this->syncPostmarkStatusFromDetails($log, $payload, $messageId);
 
         return [
             'available' => true,
             'provider' => 'Postmark',
             'message_id' => $messageId,
             'subject' => $payload['Subject'] ?? $log->subject,
-            'status' => $payload['Status'] ?? null,
+            'status' => $logStatus ?? $payload['Status'] ?? null,
             'message_stream' => $payload['MessageStream'] ?? $log->provider_message_stream,
             'events' => $payload['MessageEvents'] ?? [],
             'raw' => $payload,
@@ -140,5 +141,38 @@ class EmailProviderDetailsService
         }
 
         return (string) data_get($response->json(), 'Messages.0.MessageID', '');
+    }
+
+    private function syncPostmarkStatusFromDetails(EmailLog $log, array $payload, string $messageId): ?string
+    {
+        $events = collect($payload['MessageEvents'] ?? []);
+        $status = null;
+        $summary = null;
+
+        if ($events->contains(fn ($event) => ($event['Type'] ?? $event['RecordType'] ?? null) === 'SpamComplaint')) {
+            $status = 'permanent_failed';
+            $summary = 'Postmark spam complaint';
+        } elseif ($events->contains(fn ($event) => in_array(($event['Type'] ?? $event['RecordType'] ?? null), ['Bounced', 'Bounce'], true))) {
+            $status = 'permanent_failed';
+            $summary = 'Postmark bounce';
+        } elseif ($events->contains(fn ($event) => ($event['Type'] ?? $event['RecordType'] ?? null) === 'Transient')) {
+            $status = 'failed';
+            $event = $events->first(fn ($event) => ($event['Type'] ?? $event['RecordType'] ?? null) === 'Transient');
+            $summary = 'Postmark transient delivery issue: ' . (data_get($event, 'Details.DeliveryMessage') ?: data_get($event, 'Description') ?: 'Temporary delivery issue');
+        }
+
+        $updates = [
+            'provider_message_id' => $messageId,
+            'provider_message_stream' => $payload['MessageStream'] ?? $log->provider_message_stream,
+        ];
+
+        if ($status !== null) {
+            $updates['status'] = $status;
+            $updates['sent_debug_info'] = $summary;
+        }
+
+        $log->forceFill($updates)->save();
+
+        return $status;
     }
 }

--- a/resources/js/Pages/Logs.vue
+++ b/resources/js/Pages/Logs.vue
@@ -158,6 +158,7 @@ const testEmailErrors = ref({})
 const testEmailForm = reactive({
     email: '',
 })
+const testEmailRefreshTimers = []
 
 
 const pages = [
@@ -202,6 +203,10 @@ onMounted(() => {
     }
 })
 
+onUnmounted(() => {
+    testEmailRefreshTimers.forEach((timer) => clearTimeout(timer))
+})
+
 
 const notificationType = ref(null);
 const notificationShow = ref(null);
@@ -240,6 +245,7 @@ const sendTestEmail = () => {
         notificationMessages.value = response.data.messages
         notificationShow.value = true
         emailsTrigger.value = !emailsTrigger.value
+        scheduleTestEmailRefreshes(response.data.log_uuid)
     }).catch((error) => {
         testEmailErrors.value = error.response?.data?.errors ?? {}
         notificationType.value = 'error'
@@ -250,6 +256,26 @@ const sendTestEmail = () => {
     }).finally(() => {
         testEmailLoading.value = false
     })
+}
+
+const scheduleTestEmailRefreshes = (logUuid = null) => {
+    ;[15000, 60000].forEach((delay) => {
+        testEmailRefreshTimers.push(setTimeout(() => {
+            refreshTestEmailLog(logUuid)
+        }, delay))
+    })
+}
+
+const refreshTestEmailLog = (logUuid = null) => {
+    if (!logUuid || !props.routes.email_delivery_details) {
+        emailsTrigger.value = !emailsTrigger.value
+        return
+    }
+
+    axios.get(props.routes.email_delivery_details.replace('__UUID__', logUuid))
+        .finally(() => {
+            emailsTrigger.value = !emailsTrigger.value
+        })
 }
 
 

--- a/resources/js/Pages/components/EmailLogs.vue
+++ b/resources/js/Pages/components/EmailLogs.vue
@@ -326,6 +326,7 @@ const data = ref({
 });
 const expandedRow = ref(null)
 const domainFilterKey = ref(0)
+const deliveryStatusSyncs = new Map()
 
 
 const startLocal = moment.utc(props.startPeriod).tz(props.timezone)
@@ -377,6 +378,7 @@ const fetchData = async (page = 1) => {
     })
         .then((response) => {
             data.value = response.data;
+            syncVisibleDeliveryStatuses();
             // console.log(data.value);
 
         }).catch((error) => {
@@ -390,6 +392,29 @@ const fetchData = async (page = 1) => {
 watch(() => props.trigger, (newVal) => {
     fetchData(1)
 })
+
+const syncVisibleDeliveryStatuses = () => {
+    const rows = data.value.data ?? [];
+    const now = Date.now();
+    const rowsToSync = rows.filter((row) => {
+        const lastSync = deliveryStatusSyncs.get(row.uuid) ?? 0;
+
+        return row.provider === 'postmark'
+            && row.status === 'sent'
+            && now - lastSync > 30000
+            && canShowDeliveryDetails(row);
+    });
+
+    if (!rowsToSync.length) return;
+
+    rowsToSync.forEach((row) => deliveryStatusSyncs.set(row.uuid, now));
+
+    Promise.allSettled(rowsToSync.map((row) => {
+        return axios.get(props.routes.email_delivery_details.replace('__UUID__', row.uuid));
+    })).then(() => {
+        fetchData(data.value.current_page || 1);
+    });
+}
 
 const toggleExpand = (uuid) => {
     expandedRow.value = expandedRow.value === uuid ? null : uuid;
@@ -529,6 +554,7 @@ const handleDeliveryDetails = (row) => {
     axios.get(props.routes.email_delivery_details.replace('__UUID__', row.uuid))
         .then((response) => {
             deliveryDetails.value = response.data;
+            fetchData(data.value.current_page || 1);
         }).catch((error) => {
             deliveryDetails.value = {
                 available: false,


### PR DESCRIPTION
- Test email send would falsely claim that the test email was unsuccessful
- Mobile app emails were not getting filtered properly to the domain name. Mobile app credential emails now include the extension’s domain_uuid, so they appear under the current domain filter instead of only under All Domains.
- Postmark users will have the page refresh to monitor delivery issues. This is the 1st release of this feature and will be further tweaked upon feedback 