### PR TITLE
Also update Display Name/Label when changing extension number

### DIFF
--- a/app/Observers/ExtensionObserver.php
+++ b/app/Observers/ExtensionObserver.php
@@ -70,13 +70,24 @@ class ExtensionObserver
                 $deviceLineData['user_id'] = $extension->extension;
             }
 
-            DeviceLines::where('domain_uuid', $extension->domain_uuid)
+            $deviceLines = DeviceLines::where('domain_uuid', $extension->domain_uuid)
                 ->where('auth_id', $oldExtension)
                 ->where(function ($query) {
                     $query->whereNull('external_line')
                         ->orWhere('external_line', '!=', 't');
-                })
-                ->update($deviceLineData);
+                });
+
+            if ($extension->wasChanged('extension')) {
+                (clone $deviceLines)
+                    ->where('label', $oldExtension)
+                    ->update(['label' => $extension->extension]);
+
+                (clone $deviceLines)
+                    ->where('display_name', $oldExtension)
+                    ->update(['display_name' => $extension->extension]);
+            }
+
+            $deviceLines->update($deviceLineData);
         }
 
         // Get the attributes from the model


### PR DESCRIPTION
Just like when changing a SIP password or extension, it updates the associated device record, we are also updating the associated record for the Display Name and Label - ONLY IF these two fields are equal to the extension number. It will NOT overwrite if a custom name has been defined for these fields.