### PR TITLE
Add Twilio messaging provider (SMS/MMS)

### DIFF
--- a/app/Http/Controllers/MessageSettingsController.php
+++ b/app/Http/Controllers/MessageSettingsController.php
@@ -96,6 +96,7 @@ class MessageSettingsController extends Controller
                 ['value' => 'telnyx', 'label' => 'Telnyx'],
                 ['value' => 'thinq', 'label' => 'Commio (ThinQ)'],
                 ['value' => 'voipms', 'label' => 'VoIP.MS'],
+                ['value' => 'twilio', 'label' => 'Twilio'],
             ];
 
             // Define the options for the 'chatplan_detail_data' field

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -27,5 +27,6 @@ class VerifyCsrfToken extends Middleware
         'webhook/bulkvs/sms',
         'webhook/voipms/sms',
         'webhook/fibernetics/sms',
+        'webhook/twilio/sms'
     ];
 }

--- a/app/Http/Webhooks/Jobs/ProcessTwilioWebhookJob.php
+++ b/app/Http/Webhooks/Jobs/ProcessTwilioWebhookJob.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Webhooks\Jobs;
+
+use App\Services\Messaging\Providers\MessagingWebhookParser;
+use App\Services\Messaging\Providers\TwilioWebhookParser;
+
+class ProcessTwilioWebhookJob extends ProcessMessagingWebhookJob
+{
+    protected function parser(): MessagingWebhookParser
+    {
+        messaging_webhook_debug('ProcessTwilioWebhookJob parser() resolved', [
+            'parser' => TwilioWebhookParser::class,
+        ]);
+
+        return app(TwilioWebhookParser::class);
+    }
+}

--- a/app/Http/Webhooks/SignatureValidators/TwilioSignatureValidator.php
+++ b/app/Http/Webhooks/SignatureValidators/TwilioSignatureValidator.php
@@ -42,7 +42,7 @@ class TwilioSignatureValidator implements SignatureValidator
     protected function computeSignature(Request $request, string $authToken): string
     {
         $url    = $request->fullUrl();
-        $params = $request->post();
+        $params = $this->originalPostParams($request);
 
         ksort($params);
 
@@ -52,5 +52,30 @@ class TwilioSignatureValidator implements SignatureValidator
         }
 
         return base64_encode(hash_hmac('sha1', $data, $authToken, true));
+    }
+
+    /**
+     * Recover the original, unmodified POST parameters from the raw request body.
+     *
+     * We cannot use $request->post() here: Laravel's TrimStrings and
+     * ConvertEmptyStringsToNull middleware run before this validator and mutate
+     * the parameter bag, which changes the recomputed hash and breaks signature
+     * verification (notably for Messaging Service webhooks). Twilio signs the
+     * values exactly as sent, so we parse them straight from the raw body.
+     *
+     * @return array<string, mixed>
+     */
+    protected function originalPostParams(Request $request): array
+    {
+        $content = $request->getContent();
+
+        if ($content === '') {
+            return $request->post();
+        }
+
+        $params = [];
+        parse_str($content, $params);
+
+        return $params;
     }
 }

--- a/app/Http/Webhooks/SignatureValidators/TwilioSignatureValidator.php
+++ b/app/Http/Webhooks/SignatureValidators/TwilioSignatureValidator.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Webhooks\SignatureValidators;
+
+use Illuminate\Http\Request;
+use Spatie\WebhookClient\SignatureValidator\SignatureValidator;
+use Spatie\WebhookClient\WebhookConfig;
+
+class TwilioSignatureValidator implements SignatureValidator
+{
+    public function isValid(Request $request, WebhookConfig $config): bool
+    {
+        $twilioSignature = (string) $request->header('X-Twilio-Signature', '');
+        $authToken       = (string) config('twilio.auth_token');
+
+        if ($twilioSignature === '' || $authToken === '') {
+            messaging_webhook_debug('TwilioSignatureValidator missing signature or auth token', [
+                'has_signature' => $twilioSignature !== '',
+                'has_auth_token' => $authToken !== '',
+            ]);
+
+            return false;
+        }
+
+        $expected = $this->computeSignature($request, $authToken);
+        $isValid  = hash_equals($expected, $twilioSignature);
+
+        messaging_webhook_debug('TwilioSignatureValidator verification completed', [
+            'is_valid' => $isValid,
+        ]);
+
+        return $isValid;
+    }
+
+    /**
+     * Twilio signature algorithm:
+     * 1. Start with the full request URL
+     * 2. Sort POST params alphabetically by key
+     * 3. Append each {key}{value} (no separator) to the URL string
+     * 4. HMAC-SHA1 the result using auth_token, then Base64-encode
+     */
+    protected function computeSignature(Request $request, string $authToken): string
+    {
+        $url    = $request->fullUrl();
+        $params = $request->post();
+
+        ksort($params);
+
+        $data = $url;
+        foreach ($params as $key => $value) {
+            $data .= $key . $value;
+        }
+
+        return base64_encode(hash_hmac('sha1', $data, $authToken, true));
+    }
+}

--- a/app/Http/Webhooks/WebhookProfiles/TwilioWebhookProfile.php
+++ b/app/Http/Webhooks/WebhookProfiles/TwilioWebhookProfile.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Webhooks\WebhookProfiles;
+
+use Illuminate\Http\Request;
+use Spatie\WebhookClient\WebhookProfile\WebhookProfile;
+
+class TwilioWebhookProfile implements WebhookProfile
+{
+    public function shouldProcess(Request $request): bool
+    {
+        $payload = $request->all();
+
+        // Both inbound messages and delivery status callbacks include MessageSid (or SmsSid).
+        $shouldProcess = isset($payload['MessageSid']) || isset($payload['SmsSid']);
+
+        messaging_webhook_debug('TwilioWebhookProfile shouldProcess()', [
+            'has_message_sid' => isset($payload['MessageSid']),
+            'has_sms_sid'     => isset($payload['SmsSid']),
+            'should_process'  => $shouldProcess,
+        ]);
+
+        return $shouldProcess;
+    }
+}

--- a/app/Services/Messaging/Outbound/Providers/TwilioOutboundProvider.php
+++ b/app/Services/Messaging/Outbound/Providers/TwilioOutboundProvider.php
@@ -58,9 +58,16 @@ class TwilioOutboundProvider implements OutboundProviderInterface
             $payload['Body'] = $text;
         }
 
-        foreach (array_slice($mediaUrls, 0, 10) as $url) {
-            $payload['MediaUrl[]'] = $url;
+        // Twilio expects the MediaUrl parameter repeated for each attachment,
+        // which PHP form encoding cannot express, so build the body manually.
+        $formPairs = [];
+        foreach ($payload as $key => $value) {
+            $formPairs[] = urlencode($key) . '=' . urlencode($value);
         }
+        foreach (array_slice($mediaUrls, 0, 10) as $url) {
+            $formPairs[] = 'MediaUrl=' . urlencode($url);
+        }
+        $formBody = implode('&', $formPairs);
 
         $endpoint = "{$baseUrl}/Accounts/{$accountSid}/Messages.json";
 
@@ -68,14 +75,15 @@ class TwilioOutboundProvider implements OutboundProviderInterface
             'message_uuid' => $message->message_uuid,
             'endpoint'     => $endpoint,
             'payload'      => $payload,
+            'media_urls'   => array_slice($mediaUrls, 0, 10),
         ]);
 
         try {
             $response = Http::withBasicAuth($accountSid, $authToken)
-                ->asForm()
+                ->withBody($formBody, 'application/x-www-form-urlencoded')
                 ->acceptJson()
                 ->timeout(30)
-                ->post($endpoint, $payload);
+                ->post($endpoint);
 
             $result = $response->json();
 

--- a/app/Services/Messaging/Outbound/Providers/TwilioOutboundProvider.php
+++ b/app/Services/Messaging/Outbound/Providers/TwilioOutboundProvider.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace App\Services\Messaging\Outbound\Providers;
+
+use App\Models\Messages;
+use App\Services\Messaging\Outbound\Contracts\OutboundProviderInterface;
+use App\Services\Messaging\Outbound\Data\OutboundSendResultData;
+use Illuminate\Support\Facades\Http;
+use Throwable;
+
+class TwilioOutboundProvider implements OutboundProviderInterface
+{
+    public function send(Messages $message): OutboundSendResultData
+    {
+        messaging_webhook_debug('TwilioOutboundProvider send() started', [
+            'message_uuid' => $message->message_uuid,
+            'source' => $message->source,
+            'destination' => $message->destination,
+            'type' => $message->type,
+        ]);
+
+        $accountSid = (string) config('twilio.account_sid');
+        $authToken  = (string) config('twilio.auth_token');
+        $baseUrl    = rtrim((string) config('twilio.base_url'), '/');
+
+        if ($accountSid === '' || $authToken === '') {
+            return OutboundSendResultData::from([
+                'success' => false,
+                'status'  => 'failed',
+                'error'   => 'Twilio credentials are not configured',
+            ]);
+        }
+
+        $text      = trim((string) ($message->message ?? ''));
+        $mediaUrls = $this->buildMediaUrls($message);
+        $hasMedia  = ! empty($mediaUrls);
+
+        messaging_webhook_debug('TwilioOutboundProvider media resolved', [
+            'message_uuid' => $message->message_uuid,
+            'media_count'  => count($mediaUrls),
+            'media_urls'   => $mediaUrls,
+        ]);
+
+        if ($text === '' && ! $hasMedia) {
+            return OutboundSendResultData::from([
+                'success' => false,
+                'status'  => 'failed',
+                'error'   => 'Message has no text or media',
+            ]);
+        }
+
+        $payload = [
+            'From' => (string) $message->source,
+            'To'   => (string) $message->destination,
+        ];
+
+        if ($text !== '') {
+            $payload['Body'] = $text;
+        }
+
+        foreach (array_slice($mediaUrls, 0, 10) as $url) {
+            $payload['MediaUrl[]'] = $url;
+        }
+
+        $endpoint = "{$baseUrl}/Accounts/{$accountSid}/Messages.json";
+
+        messaging_webhook_debug('TwilioOutboundProvider request payload', [
+            'message_uuid' => $message->message_uuid,
+            'endpoint'     => $endpoint,
+            'payload'      => $payload,
+        ]);
+
+        try {
+            $response = Http::withBasicAuth($accountSid, $authToken)
+                ->asForm()
+                ->acceptJson()
+                ->timeout(30)
+                ->post($endpoint, $payload);
+
+            $result = $response->json();
+
+            messaging_webhook_debug('TwilioOutboundProvider response received', [
+                'message_uuid' => $message->message_uuid,
+                'http_status'  => $response->status(),
+                'response'     => $result,
+            ]);
+
+            if ($response->successful() && is_array($result) && isset($result['sid'])) {
+                $providerStatus = strtolower((string) ($result['status'] ?? 'queued'));
+
+                return OutboundSendResultData::from([
+                    'success'             => true,
+                    'status'              => $this->mapSuccessStatus($providerStatus),
+                    'providerReferenceId' => $result['sid'],
+                    'providerResponse'    => $result,
+                ]);
+            }
+
+            return OutboundSendResultData::from([
+                'success'             => false,
+                'status'              => 'failed',
+                'error'               => $this->extractError($result, $response->body()),
+                'providerReferenceId' => is_array($result) ? ($result['sid'] ?? null) : null,
+                'providerResponse'    => is_array($result) ? $result : [],
+            ]);
+        } catch (Throwable $e) {
+            messaging_webhook_debug('TwilioOutboundProvider exception', [
+                'message_uuid' => $message->message_uuid,
+                'error'        => $e->getMessage(),
+                'file'         => $e->getFile(),
+                'line'         => $e->getLine(),
+            ]);
+
+            return OutboundSendResultData::from([
+                'success'          => false,
+                'status'           => 'failed',
+                'error'            => $e->getMessage(),
+                'providerResponse' => [
+                    'exception' => $e->getMessage(),
+                    'file'      => $e->getFile(),
+                    'line'      => $e->getLine(),
+                ],
+            ]);
+        }
+    }
+
+    protected function mapSuccessStatus(string $providerStatus): string
+    {
+        return match ($providerStatus) {
+            'queued', 'accepted', 'scheduled', 'sending', 'sent' => 'queued',
+            'delivered' => 'success',
+            default => 'queued',
+        };
+    }
+
+    protected function extractError(mixed $result, string $fallback): string
+    {
+        if (is_array($result)) {
+            if (! empty($result['message'])) {
+                $code = $result['code'] ?? null;
+
+                return $code ? "Code {$code}: {$result['message']}" : (string) $result['message'];
+            }
+
+            return json_encode($result);
+        }
+
+        return $fallback;
+    }
+
+    protected function buildMediaUrls(Messages $message): array
+    {
+        return collect($this->decodeMedia($message->media))
+            ->map(function ($item) {
+                if (is_string($item) && ! empty($item)) {
+                    return $item;
+                }
+
+                if (is_array($item) && ! empty($item['access_path'])) {
+                    return filter_var($item['access_path'], FILTER_VALIDATE_URL)
+                        ? $item['access_path']
+                        : url($item['access_path']);
+                }
+
+                if (is_array($item) && ! empty($item['url'])) {
+                    return $item['url'];
+                }
+
+                return null;
+            })
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    protected function decodeMedia($media): array
+    {
+        if (is_string($media)) {
+            $decoded = json_decode($media, true);
+
+            return is_array($decoded) ? $decoded : [];
+        }
+
+        return is_array($media) ? $media : [];
+    }
+}

--- a/app/Services/Messaging/Providers/TwilioWebhookParser.php
+++ b/app/Services/Messaging/Providers/TwilioWebhookParser.php
@@ -34,8 +34,11 @@ class TwilioWebhookParser implements MessagingWebhookParser
             return;
         }
 
-        // Delivery status callback has a MessageStatus (or SmsStatus) field.
-        if ($messageStatus !== '') {
+        // Twilio sends MessageStatus/SmsStatus = "received" on INBOUND messages, and one of
+        // queued/sent/delivered/undelivered/failed on delivery-status callbacks. Only the
+        // latter set should be treated as a delivery status event — "received" (or an empty
+        // status) is an inbound message.
+        if ($messageStatus !== '' && strtolower($messageStatus) !== 'received') {
             $event = DeliveryStatusEventData::from([
                 'provider'      => 'twilio',
                 'referenceId'   => $messageSid,

--- a/app/Services/Messaging/Providers/TwilioWebhookParser.php
+++ b/app/Services/Messaging/Providers/TwilioWebhookParser.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace App\Services\Messaging\Providers;
+
+use App\Services\Messaging\Data\DeliveryStatusEventData;
+use App\Services\Messaging\Data\DownloadedMediaData;
+use App\Services\Messaging\Data\InboundMessageEventData;
+use Illuminate\Support\Facades\Http;
+use libphonenumber\PhoneNumberFormat;
+use Spatie\WebhookClient\Models\WebhookCall;
+use Throwable;
+
+class TwilioWebhookParser implements MessagingWebhookParser
+{
+    /**
+     * @return iterable<object>
+     */
+    public function parse(WebhookCall $webhookCall): iterable
+    {
+        $payload = $webhookCall->payload ?? [];
+
+        $messageSid    = (string) ($payload['MessageSid'] ?? ($payload['SmsSid'] ?? ''));
+        $messageStatus = (string) ($payload['MessageStatus'] ?? ($payload['SmsStatus'] ?? ''));
+
+        messaging_webhook_debug('TwilioWebhookParser parse() started', [
+            'message_sid'    => $messageSid,
+            'message_status' => $messageStatus,
+            'has_body'       => array_key_exists('Body', $payload),
+        ]);
+
+        if (! is_array($payload) || $messageSid === '') {
+            messaging_webhook_debug('TwilioWebhookParser invalid payload — missing MessageSid');
+
+            return;
+        }
+
+        // Delivery status callback has a MessageStatus (or SmsStatus) field.
+        if ($messageStatus !== '') {
+            $event = DeliveryStatusEventData::from([
+                'provider'      => 'twilio',
+                'referenceId'   => $messageSid,
+                'status'        => $this->mapDeliveryStatus($messageStatus),
+                'description'   => $this->extractDeliveryDescription($payload, $messageStatus),
+                'providerEvent' => 'delivery_status',
+            ]);
+
+            messaging_webhook_debug('TwilioWebhookParser delivery event parsed', [
+                'reference_id'    => $event->referenceId,
+                'provider_status' => $messageStatus,
+                'local_status'    => $event->status,
+                'description'     => $event->description,
+            ]);
+
+            yield $event;
+
+            return;
+        }
+
+        // Inbound message: must have From/To (Body may be empty for MMS-only messages).
+        $from = $this->normalizePhoneNumber((string) ($payload['From'] ?? ''));
+        $to   = $this->normalizePhoneNumber((string) ($payload['To'] ?? ''));
+
+        if ($from === null || $to === null) {
+            messaging_webhook_debug('TwilioWebhookParser could not resolve From/To', [
+                'from_raw' => $payload['From'] ?? null,
+                'to_raw'   => $payload['To'] ?? null,
+            ]);
+
+            return;
+        }
+
+        $mediaUrls = $this->extractMediaUrls($payload);
+
+        $event = InboundMessageEventData::from([
+            'provider'            => 'twilio',
+            'providerReferenceId' => $messageSid,
+            'from'                => $from,
+            'to'                  => [$to],
+            'text'                => trim((string) ($payload['Body'] ?? '')),
+            'mediaUrls'           => $mediaUrls,
+            'providerEvent'       => 'message.received',
+        ]);
+
+        messaging_webhook_debug('TwilioWebhookParser inbound event parsed', [
+            'provider_reference_id' => $event->providerReferenceId,
+            'from'                  => $event->from,
+            'to'                    => $event->to,
+            'text_length'           => strlen((string) $event->text),
+            'media_count'           => count($mediaUrls),
+        ]);
+
+        yield $event;
+    }
+
+    public function downloadMedia(string $url): DownloadedMediaData
+    {
+        messaging_webhook_debug('TwilioWebhookParser downloadMedia() started', [
+            'url' => $url,
+        ]);
+
+        $accountSid = (string) config('twilio.account_sid');
+        $authToken  = (string) config('twilio.auth_token');
+
+        $response = Http::withBasicAuth($accountSid, $authToken)
+            ->timeout(60)
+            ->accept('*/*')
+            ->get($url);
+
+        $response->throw();
+
+        $binary       = $response->body();
+        $mimeType     = $response->header('Content-Type') ?: 'application/octet-stream';
+        $originalName = $this->extractFilenameFromUrl($url, $mimeType);
+
+        messaging_webhook_debug('TwilioWebhookParser downloadMedia() completed', [
+            'url'           => $url,
+            'mime_type'     => $mimeType,
+            'size'          => strlen($binary),
+            'original_name' => $originalName,
+        ]);
+
+        return DownloadedMediaData::from([
+            'binary'       => $binary,
+            'originalName' => $originalName,
+            'mimeType'     => $mimeType,
+            'size'         => strlen($binary),
+            'sourceUrl'    => $url,
+        ]);
+    }
+
+    protected function extractMediaUrls(array $payload): array
+    {
+        $numMedia = (int) ($payload['NumMedia'] ?? 0);
+        $urls     = [];
+
+        for ($i = 0; $i < $numMedia; $i++) {
+            $url = $payload["MediaUrl{$i}"] ?? null;
+
+            if ($url && filter_var($url, FILTER_VALIDATE_URL)) {
+                $urls[] = $url;
+            }
+        }
+
+        return $urls;
+    }
+
+    protected function mapDeliveryStatus(string $providerStatus): string
+    {
+        return match ($providerStatus) {
+            'delivered' => 'delivered',
+            'undelivered', 'failed' => 'failed',
+            default => 'failed',
+        };
+    }
+
+    protected function extractDeliveryDescription(array $payload, string $providerStatus): ?string
+    {
+        $errorCode    = $payload['ErrorCode'] ?? null;
+        $errorMessage = $payload['ErrorMessage'] ?? null;
+
+        if ($errorCode || $errorMessage) {
+            return implode(': ', array_filter([$errorCode ? "Code {$errorCode}" : null, $errorMessage]));
+        }
+
+        return $providerStatus !== '' ? $providerStatus : null;
+    }
+
+    protected function normalizePhoneNumber(?string $number): ?string
+    {
+        if (! filled($number)) {
+            return null;
+        }
+
+        try {
+            return formatPhoneNumber(
+                $number,
+                get_domain_setting('country') ?? 'US',
+                PhoneNumberFormat::E164
+            );
+        } catch (Throwable) {
+            $digits = preg_replace('/\D+/', '', (string) $number);
+
+            return $digits ? '+' . $digits : null;
+        }
+    }
+
+    protected function extractFilenameFromUrl(string $url, string $mimeType): string
+    {
+        $path     = parse_url($url, PHP_URL_PATH) ?: '';
+        $filename = basename($path);
+
+        if ($filename && str_contains($filename, '.')) {
+            return $filename;
+        }
+
+        return 'attachment.' . $this->extensionFromMimeType($mimeType);
+    }
+
+    protected function extensionFromMimeType(string $mimeType): string
+    {
+        return match (strtolower(trim(explode(';', $mimeType)[0]))) {
+            'image/jpeg' => 'jpg',
+            'image/png'  => 'png',
+            'image/gif'  => 'gif',
+            'image/webp' => 'webp',
+            'video/mp4'  => 'mp4',
+            'audio/mpeg' => 'mp3',
+            'application/pdf' => 'pdf',
+            'text/plain' => 'txt',
+            default      => 'bin',
+        };
+    }
+}

--- a/config/messaging.php
+++ b/config/messaging.php
@@ -13,5 +13,6 @@ return [
         'thinq' => \App\Services\Messaging\Outbound\Providers\CommioOutboundProvider::class,
         'voipms' => \App\Services\Messaging\Outbound\Providers\VoipMsOutboundProvider::class,
         'fibernetics' => \App\Services\Messaging\Outbound\Providers\FiberneticsOutboundProvider::class,
+        'twilio' => \App\Services\Messaging\Outbound\Providers\TwilioOutboundProvider::class,
     ],
 ];

--- a/config/twilio.php
+++ b/config/twilio.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'account_sid' => env('TWILIO_ACCOUNT_SID'),
+    'auth_token'  => env('TWILIO_AUTH_TOKEN'),
+    'base_url'    => env('TWILIO_BASE_URL', 'https://api.twilio.com/2010-04-01'),
+];

--- a/config/webhook-client.php
+++ b/config/webhook-client.php
@@ -744,6 +744,18 @@ return [
             'process_webhook_job' => \App\Http\Webhooks\Jobs\ProcessFiberneticsWebhookJob::class,
         ],
 
+        [
+            'name'                  => 'twilio_messaging',
+            'signing_secret'        => env('TWILIO_AUTH_TOKEN'),
+            'signature_header_name' => 'X-Twilio-Signature',
+            'signature_validator'   => \App\Http\Webhooks\SignatureValidators\TwilioSignatureValidator::class,
+            'webhook_profile'       => \App\Http\Webhooks\WebhookProfiles\TwilioWebhookProfile::class,
+            'webhook_response'      => \Spatie\WebhookClient\WebhookResponse\DefaultRespondsTo::class,
+            'webhook_model'         => \App\Models\WhCall::class,
+            'store_headers'         => [],
+            'process_webhook_job'   => \App\Http\Webhooks\Jobs\ProcessTwilioWebhookJob::class,
+        ],
+
     ],
 
     /*

--- a/documentation/docs/tutorials/05-configuration/06-messaging/09-twilio.md
+++ b/documentation/docs/tutorials/05-configuration/06-messaging/09-twilio.md
@@ -1,0 +1,155 @@
+---
+id: twilio
+title: Twilio SMS Provider Configuration
+slug: /configuration/messaging/twilio
+description: Configure Twilio for SMS and MMS in FS PBX.
+sidebar_position: 9
+---
+
+Twilio SMS Provider Configuration
+=================================
+
+FS PBX provides two-way SMS and MMS support via **Twilio**, including inbound message handling, outbound delivery, delivery-status callbacks, and webhook signature verification for security. This guide explains how to configure your Twilio credentials and enable SMS routing to extensions.
+
+* * * * *
+
+1\. Prerequisites
+-----------------
+
+-   A Twilio account with an SMS-capable phone number.
+
+-   **US numbers: A2P 10DLC registration is required.** Twilio blocks outbound SMS/MMS from unregistered US local (10-digit) numbers. Register a **Brand** and **Campaign** in the Twilio Console under **Messaging → Regulatory Compliance**, and attach your number to the campaign before sending. Toll-free numbers require **Toll-Free Verification** instead.
+
+* * * * *
+
+2\. Required Environment Variables
+----------------------------------
+
+Add **all** required environment variables to your `.env` file:
+
+```
+TWILIO_ACCOUNT_SID=
+TWILIO_AUTH_TOKEN=
+TWILIO_BASE_URL=https://api.twilio.com/2010-04-01
+```
+
+### Variable Description
+
+| Variable | Purpose |
+| --- | --- |
+| **TWILIO_ACCOUNT_SID** | Your Twilio Account SID (starts with `AC`). Used to authenticate API requests and download MMS media. |
+| **TWILIO_AUTH_TOKEN** | Your Twilio Auth Token. Used for outbound API authentication **and** to verify inbound webhook signatures. |
+| **TWILIO_BASE_URL** | API endpoint for Twilio requests. Default: `https://api.twilio.com/2010-04-01`. |
+
+You can find both values on the Twilio Console dashboard under **Account Info**.
+
+3\. Apply Configuration Changes
+-------------------------------
+
+After updating your `.env` file, run:
+
+`php artisan config:cache`
+
+This is required for FS PBX to load updated provider settings.
+
+* * * * *
+
+4\. Webhook Setup (Required)
+----------------------------
+
+Twilio delivers inbound SMS/MMS messages and delivery-status events through webhooks.\
+To ensure FS PBX receives and processes incoming messages, set the webhook URL for your Twilio phone number to:
+
+`https://your-domain/webhook/twilio/sms`
+
+### Where to Configure in Twilio
+
+1.  Log in to the **Twilio Console**
+
+2.  Go to **Phone Numbers → Manage → Active Numbers**
+
+3.  Select your phone number
+
+4.  Under **Messaging Configuration**, set:
+
+    -   **A message comes in** → Webhook → `https://your-domain/webhook/twilio/sms` → HTTP POST
+
+5.  Save
+
+If your number is attached to a **Messaging Service**, configure the inbound webhook on the Messaging Service instead (**Messaging → Services → your service → Integration → Send a webhook**).
+
+### Delivery-Status Callbacks (Optional)
+
+To have outbound messages update to **delivered** or **failed** in FS PBX, set the **Delivery status callback** on your number or Messaging Service to the same URL:
+
+`https://your-domain/webhook/twilio/sms`
+
+### Webhook Signature Validation
+
+FS PBX validates the `X-Twilio-Signature` header on every incoming webhook using your `TWILIO_AUTH_TOKEN`.
+
+-   If the signature is invalid
+
+-   If the auth token doesn't match
+
+-   Or if the signature header is missing
+
+...FS PBX will reject the request automatically.
+
+This helps ensure **only authentic requests from Twilio** are processed.
+
+* * * * *
+
+5\. Enable SMS on a Phone Number in FS PBX
+------------------------------------------
+
+After credentials and webhook configuration are complete:
+
+1.  Go to **Advanced → Message Settings**
+
+2.  Add or edit an SMS-enabled number
+
+3.  Select **Twilio** as the provider
+
+4.  Assign an **extension** for mobile app delivery
+
+5.  Optionally assign an **email address** for read-only email notifications
+
+When configured:
+
+-   Inbound SMS → Twilio → FS PBX → Extension's Mobile App
+
+-   Replies → FS PBX → Twilio → Original Sender
+
+* * * * *
+
+## 6. MMS Support
+
+If your Twilio number supports MMS, FS PBX can also process media attachments sent through the same messaging flow. Inbound media is downloaded from Twilio using your account credentials and stored in your configured object storage.
+
+To use MMS media storage, S3-compatible storage must already be configured in your system. See the [S3 Configuration for Messages](/docs/configuration/messaging/s3-config-for-messages/) guide.
+
+This allows users to:
+
+* receive inbound picture messages in the mobile app
+* reply to supported MMS conversations
+* keep SMS and MMS history together in the same conversation thread
+
+---
+
+Summary
+-------
+
+For full Twilio SMS integration:
+
+1.  Complete A2P 10DLC registration (US numbers)
+
+2.  Add `.env` variables (`TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`)
+
+3.  Run `php artisan config:cache`
+
+4.  Configure Twilio webhooks to `/webhook/twilio/sms`
+
+5.  Enable SMS for each number in **Message Settings**
+
+Your Twilio numbers are now ready for reliable two-way SMS.

--- a/routes/web.php
+++ b/routes/web.php
@@ -118,6 +118,7 @@ Route::webhooks('webhook/voipms/sms', 'voipms_messaging');
 Route::webhooks('webhook/fibernetics/sms', 'fibernetics_messaging', 'get');
 Route::post('webhook/fibernetics/sms', FiberneticsMmsWebhookController::class)
     ->name('webhook.fibernetics.mms');
+Route::webhooks('webhook/twilio/sms', 'twilio_messaging');
 Route::webhooks('/sms/ringotelwebhook', 'ringotel_messaging');
 Route::webhooks('/webhook/freeswitch', 'freeswitch');
 Route::webhooks('/webhook/stripe', 'stripe');


### PR DESCRIPTION
## Summary

Adds Twilio as a messaging carrier, following the same provider architecture as the existing Telnyx/Sinch/Bandwidth/Fibernetics integrations. No changes to shared messaging code.

**New components:**
- `TwilioWebhookParser` — parses inbound SMS/MMS webhooks and delivery-status callbacks; extracts media via `NumMedia`/`MediaUrlN` and downloads it through the Twilio API (Basic auth) into FS PBX's existing media storage
- `TwilioOutboundProvider` — sends SMS/MMS via the Twilio Messages API
- `TwilioSignatureValidator` — validates `X-Twilio-Signature` (HMAC-SHA1 over the exact URL + original POST params, per Twilio's spec)
- `TwilioWebhookProfile` + `ProcessTwilioWebhookJob` — standard spatie/laravel-webhook-client wiring
- Registrations: `config/messaging.php`, `config/webhook-client.php`, `routes/web.php` (`webhook/twilio/sms`), CSRF exclusion, and a Twilio option in the Message Settings carrier dropdown
- Documentation page for the docs site: `documentation/docs/tutorials/05-configuration/06-messaging/09-twilio.md`

## Prerequisites

- A Twilio account with an SMS-capable phone number.
- **US numbers: A2P 10DLC registration is required.** Twilio blocks outbound SMS/MMS from unregistered US local numbers — you must register a Brand and Campaign in the Twilio console (Messaging → Regulatory Compliance) and attach the number to the campaign before messages will deliver. Toll-free numbers require Toll-Free Verification instead.

## Configuration

```env
TWILIO_ACCOUNT_SID=ACxxxxxxxx
TWILIO_AUTH_TOKEN=your_auth_token
```

1. Set the extension/DID carrier to **Twilio** in Message Settings.
2. In the Twilio console, point the phone number (or Messaging Service) inbound webhook to `https://your-domain/webhook/twilio/sms` (HTTP POST).
3. Optional: set the delivery-status callback to the same URL to receive sent/delivered/failed updates.
4. MMS uses FS PBX's existing `s3_storage` domain settings (same requirement as other carriers).

## Implementation notes

- Twilio sends `MessageStatus=received` on inbound messages and `queued/sent/delivered/undelivered/failed` on status callbacks; the parser distinguishes these so inbound messages aren't misclassified as delivery receipts.
- Signature validation is computed against the raw request parameters (before framework middleware mutates them, e.g. trimming), otherwise valid Twilio signatures fail.
- Outbound MMS builds the form body manually because Twilio expects the `MediaUrl` parameter repeated once per attachment, which PHP form encoding cannot express.

## Testing

Verified on a live install (v1.9.7) with a Twilio number behind a reverse proxy:
- ✅ Inbound SMS (webhook → signature validation → stored → real-time delivery via Reverb)
- ✅ Outbound SMS from the portal
- ✅ Inbound MMS (media downloaded from Twilio, stored in S3-compatible storage via `s3_storage` settings, rendered in conversation)
- ✅ Outbound MMS from the portal
- ✅ Delivery-status callback parsing
- ✅ Coexists with the Fibernetics provider registrations (rebased onto v1.9.7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
